### PR TITLE
Use eclipse plugin for submodules only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'project-report'
 
 allprojects {
     apply plugin: 'idea'
-    apply plugin: 'eclipse'
     
     group = 'org.terasology'
     
@@ -24,6 +23,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'eclipse'
 }
 
 configure (subprojects.findAll {!it.name.contains("testpack") && !it.name.startsWith("module")}) {


### PR DESCRIPTION
eclipse is not a big fan of nested projects :-(

This avoids creating an empty eclipse project for the root project.