### PR TITLE
Tweaked the parameter ordering of AssetFactory to better correspond to a typical Asset constructor

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/AssetFactory.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/AssetFactory.java
@@ -31,9 +31,9 @@ public interface AssetFactory<T extends Asset<U>, U extends AssetData> {
 
     /**
      * @param urn  The urn of the asset to construct
-     * @param data The data for the asset
      * @param assetType The assetType the asset belongs to
+     * @param data The data for the asset
      * @return The built asset
      */
-    T build(ResourceUrn urn, U data, AssetType<T, U> assetType);
+    T build(ResourceUrn urn, AssetType<T, U> assetType, U data);
 }

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/AssetType.java
@@ -422,7 +422,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      */
     public T loadAsset(ResourceUrn urn, U data) {
         if (urn.isInstance()) {
-            return factory.build(urn, data, this);
+            return factory.build(urn, this, data);
         } else {
             T asset = loadedAssets.get(urn);
             if (asset != null) {
@@ -432,7 +432,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
                     if (!closed) {
                         asset = loadedAssets.get(urn);
                         if (asset == null) {
-                            asset = factory.build(urn, data, this);
+                            asset = factory.build(urn, this, data);
                             loadedAssets.put(urn, asset);
                         } else {
                             asset.reload(data);

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/book/BookFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/book/BookFactory.java
@@ -26,7 +26,7 @@ import org.terasology.assets.ResourceUrn;
 public class BookFactory implements AssetFactory<Book, BookData> {
 
     @Override
-    public Book build(ResourceUrn urn, BookData data, AssetType<Book, BookData> type) {
+    public Book build(ResourceUrn urn, AssetType<Book, BookData> type, BookData data) {
         return new Book(urn, data, type);
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionFactory.java
@@ -28,7 +28,7 @@ import org.terasology.assets.ResourceUrn;
 public class ExtensionFactory implements AssetFactory<ExtensionAsset, ExtensionData> {
 
     @Override
-    public ExtensionAsset build(ResourceUrn urn, ExtensionData data, AssetType<ExtensionAsset, ExtensionData> type) {
+    public ExtensionAsset build(ResourceUrn urn, AssetType<ExtensionAsset, ExtensionData> type, ExtensionData data) {
         return new ExtensionAsset(urn, data, type);
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/AlternateAssetFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/AlternateAssetFactory.java
@@ -25,7 +25,7 @@ import org.terasology.assets.ResourceUrn;
  */
 public class AlternateAssetFactory implements AssetFactory<AlternateAsset, AlternateAssetData> {
     @Override
-    public AlternateAsset build(ResourceUrn urn, AlternateAssetData data, AssetType<AlternateAsset, AlternateAssetData> type) {
+    public AlternateAsset build(ResourceUrn urn, AssetType<AlternateAsset, AlternateAssetData> type, AlternateAssetData data) {
         return new AlternateAsset(urn, data, type);
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/ChildAssetFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/ChildAssetFactory.java
@@ -25,7 +25,7 @@ import org.terasology.assets.ResourceUrn;
  */
 public class ChildAssetFactory implements AssetFactory<ChildAsset, ChildAssetData> {
     @Override
-    public ChildAsset build(ResourceUrn urn, ChildAssetData data, AssetType<ChildAsset, ChildAssetData> type) {
+    public ChildAsset build(ResourceUrn urn, AssetType<ChildAsset, ChildAssetData> type, ChildAssetData data) {
         return new ChildAsset(urn, data, type);
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/text/TextFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/text/TextFactory.java
@@ -25,7 +25,7 @@ import org.terasology.assets.ResourceUrn;
  */
 public class TextFactory implements AssetFactory<Text, TextData> {
     @Override
-    public Text build(ResourceUrn urn, TextData data, AssetType<Text, TextData> type) {
+    public Text build(ResourceUrn urn, AssetType<Text, TextData> type, TextData data) {
         return new Text(urn, data, type);
     }
 }


### PR DESCRIPTION
This allows for method references to new to easily be used instead of a formal factory.