### PR TITLE
AssetType registration tweaks and multi-subfolder support

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/AssetFactory.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/AssetFactory.java
@@ -27,6 +27,7 @@ import org.terasology.module.sandbox.API;
  * @author Immortius
  */
 @API
+@FunctionalInterface
 public interface AssetFactory<T extends Asset<U>, U extends AssetData> {
 
     /**

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/module/annotations/RegisterAssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/module/annotations/RegisterAssetType.java
@@ -43,7 +43,7 @@ public @interface RegisterAssetType {
     /**
      * @return The subdirectory where assets of this type will be discovered. Can be omitted for asset types that are not loaded from files.
      */
-    String folderName() default "";
+    String[] folderName() default {};
 
     /**
      * @return The factory class to use when generating assets of this type

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/module/annotations/RegisterAssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/module/annotations/RegisterAssetType.java
@@ -16,6 +16,7 @@
 
 package org.terasology.assets.module.annotations;
 
+import org.terasology.assets.AssetFactory;
 import org.terasology.module.sandbox.API;
 
 import java.lang.annotation.ElementType;
@@ -24,14 +25,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks an {@link org.terasology.assets.AssetFactory AssetFactory} to be automatically registered as an asset type by
+ * Marks an {@link org.terasology.assets.Asset Asset} to be automatically registered as an asset type by
  * {@link org.terasology.assets.module.ModuleAwareAssetTypeManager ModuleAwareAssetTypeManager} on environment change.
  *
  * <p>Note that asset types loaded in this way will be unloaded when switching environments, and all assets disposed. If an asset type should persist across environment
  * changes and assets reloaded instead they should be manually registered as a core asset type. This will be typically only be the case for assets types from the
  * classpath module(s)</p>
  * <p>
- * The AssetFactory must have an empty constructor, or one taking an AssetManager
+ * The AssetFactory must either have an empty constructor, or one taking an AssetManager
  * </p>
  * @author Immortius
  */
@@ -42,5 +43,10 @@ public @interface RegisterAssetType {
     /**
      * @return The subdirectory where assets of this type will be discovered. Can be omitted for asset types that are not loaded from files.
      */
-    String value() default "";
+    String folderName() default "";
+
+    /**
+     * @return The factory class to use when generating assets of this type
+     */
+    Class<? extends AssetFactory> factoryClass();
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/module/ModuleAssetDataProducerTest.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/module/ModuleAssetDataProducerTest.java
@@ -49,10 +49,8 @@ public class ModuleAssetDataProducerTest extends VirtualModuleEnvironment {
 
 
     private ModuleAssetDataProducer<TextData> createProducer(ModuleEnvironment environment) {
-        return new ModuleAssetDataProducer<>(FOLDER_NAME, environment,
-                Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()),
-                Collections.<AssetAlterationFileFormat<TextData>>emptyList(),
-                Collections.<AssetAlterationFileFormat<TextData>>emptyList());
+        return new ModuleAssetDataProducer<>(environment, Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()), Collections.<AssetAlterationFileFormat<TextData>>emptyList(), Collections.<AssetAlterationFileFormat<TextData>>emptyList(), FOLDER_NAME
+        );
     }
 
     @Test
@@ -125,11 +123,8 @@ public class ModuleAssetDataProducerTest extends VirtualModuleEnvironment {
     @Test
     public void loadWithDelta() throws Exception {
         ModuleAssetDataProducer<TextData> moduleProducer = new ModuleAssetDataProducer<>(
-                FOLDER_NAME,
-                createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("test")), moduleRegistry.getLatestModuleVersion(new Name("deltaA"))),
-                Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()),
-                Collections.<AssetAlterationFileFormat<TextData>>emptyList(),
-                Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextDeltaFileFormat()));
+                createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("test")), moduleRegistry.getLatestModuleVersion(new Name("deltaA"))), Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()), Collections.<AssetAlterationFileFormat<TextData>>emptyList(), Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextDeltaFileFormat()), FOLDER_NAME
+        );
 
         Optional<TextData> assetData = moduleProducer.getAssetData(URN);
         assertTrue(assetData.isPresent());
@@ -139,13 +134,10 @@ public class ModuleAssetDataProducerTest extends VirtualModuleEnvironment {
     @Test
     public void loadWithDeltaUnrelatedToOverride() throws Exception {
         ModuleAssetDataProducer<TextData> moduleProducer = new ModuleAssetDataProducer<>(
-                FOLDER_NAME,
                 createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("test")),
                         moduleRegistry.getLatestModuleVersion(new Name("overrideA")),
-                        moduleRegistry.getLatestModuleVersion(new Name("deltaA"))),
-                Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()),
-                Collections.<AssetAlterationFileFormat<TextData>>emptyList(),
-                Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextDeltaFileFormat()));
+                        moduleRegistry.getLatestModuleVersion(new Name("deltaA"))), Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()), Collections.<AssetAlterationFileFormat<TextData>>emptyList(), Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextDeltaFileFormat()), FOLDER_NAME
+        );
 
         Optional<TextData> assetData = moduleProducer.getAssetData(URN);
         assertTrue(assetData.isPresent());
@@ -155,13 +147,10 @@ public class ModuleAssetDataProducerTest extends VirtualModuleEnvironment {
     @Test
     public void deltaDroppedBeforeOverride() throws Exception {
         ModuleAssetDataProducer<TextData> moduleProducer = new ModuleAssetDataProducer<>(
-                FOLDER_NAME,
                 createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("test")),
                         moduleRegistry.getLatestModuleVersion(new Name("deltaA")),
-                        moduleRegistry.getLatestModuleVersion(new Name("overrideD"))),
-                Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()),
-                Collections.<AssetAlterationFileFormat<TextData>>emptyList(),
-                Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextDeltaFileFormat()));
+                        moduleRegistry.getLatestModuleVersion(new Name("overrideD"))), Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()), Collections.<AssetAlterationFileFormat<TextData>>emptyList(), Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextDeltaFileFormat()), FOLDER_NAME
+        );
 
 
         Optional<TextData> assetData = moduleProducer.getAssetData(URN);
@@ -193,11 +182,8 @@ public class ModuleAssetDataProducerTest extends VirtualModuleEnvironment {
     @Test
     public void applySupplements() throws Exception {
         ModuleAssetDataProducer<TextData> moduleProducer = new ModuleAssetDataProducer<>(
-                FOLDER_NAME,
-                createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("supplementA"))),
-                Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()),
-                Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextMetadataFileFormat()),
-                Collections.<AssetAlterationFileFormat<TextData>>emptyList());
+                createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("supplementA"))), Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()), Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextMetadataFileFormat()), Collections.<AssetAlterationFileFormat<TextData>>emptyList(), FOLDER_NAME
+        );
 
         Optional<TextData> data = moduleProducer.getAssetData(new ResourceUrn("supplementA:example"));
         assertTrue(data.isPresent());
@@ -207,11 +193,8 @@ public class ModuleAssetDataProducerTest extends VirtualModuleEnvironment {
     @Test
     public void overrideWithSupplement() throws Exception {
         ModuleAssetDataProducer<TextData> moduleProducer = new ModuleAssetDataProducer<>(
-                FOLDER_NAME,
-                createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("supplementA")), moduleRegistry.getLatestModuleVersion(new Name("overrideSupplement"))),
-                Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()),
-                Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextMetadataFileFormat()),
-                Collections.<AssetAlterationFileFormat<TextData>>emptyList());
+                createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("supplementA")), moduleRegistry.getLatestModuleVersion(new Name("overrideSupplement"))), Lists.<AssetFileFormat<TextData>>newArrayList(new TextFileFormat()), Lists.<AssetAlterationFileFormat<TextData>>newArrayList(new TextMetadataFileFormat()), Collections.<AssetAlterationFileFormat<TextData>>emptyList(), FOLDER_NAME
+        );
 
         Optional<TextData> data = moduleProducer.getAssetData(new ResourceUrn("supplementA:example"));
         assertTrue(data.isPresent());

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionAsset.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionAsset.java
@@ -19,10 +19,12 @@ package org.terasology.assets.test.stubs.extensions;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.module.annotations.RegisterAssetType;
 
 /**
  * @author Immortius
  */
+@RegisterAssetType(folderName = "extension", factoryClass = ExtensionFactory.class)
 public class ExtensionAsset extends Asset<ExtensionData> {
     private String value;
 

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionFactory.java
@@ -24,7 +24,6 @@ import org.terasology.assets.ResourceUrn;
 /**
  * @author Immortius
  */
-@RegisterAssetType("extension")
 public class ExtensionFactory implements AssetFactory<ExtensionAsset, ExtensionData> {
 
     @Override


### PR DESCRIPTION
Changed the RegisterAssetType annotation handling to expect the annotation on the Asset class rather than Factory class (in anticipation of future support for method references in annotations).

Added support for asset types having multiple subfolders (e.g. in Terasology Textures are loaded both from textures and fonts folders).