### PR TITLE
Improvements to ResourceUrn and Asset instancing

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/ResourceUrn.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/ResourceUrn.java
@@ -45,12 +45,53 @@ public final class ResourceUrn implements Comparable<ResourceUrn> {
     public static final String RESOURCE_SEPARATOR = ":";
     public static final String FRAGMENT_SEPARATOR = "#";
     public static final String INSTANCE_INDICATOR = "!instance";
-    private static final Pattern URN_PATTERN = Pattern.compile("([^:#]+):([^#!]+)(?:#([^#!]+))?(!instance)?");
+    private static final Pattern URN_PATTERN = Pattern.compile("([^:]+):([^#!]+)(?:#([^!]+))?(!instance)?");
 
     private final Name moduleName;
     private final Name resourceName;
     private final Name fragmentName;
     private final boolean instance;
+
+    /**
+     * Creates a urn with the module and resource name from the provided urn, but the fragment name provided. This urn will not be an instance urn.
+     * @param urn The urn to create this urn from
+     * @param fragmentName The fragment name this urn should have
+     */
+    public ResourceUrn(ResourceUrn urn, String fragmentName) {
+        this(urn, new Name(fragmentName), false);
+    }
+
+    /**
+     * Creates a urn with the module and resource name from the provided urn, but the fragment name provided. This urn will not be an instance urn.
+     * @param urn The urn to create this urn from
+     * @param fragmentName The fragment name this urn should have
+     */
+    public ResourceUrn(ResourceUrn urn, Name fragmentName) {
+        this(urn, fragmentName, false);
+    }
+
+    /**
+     * Creates a urn with the module and resource name from the provided urn, but the fragment name provided.
+     * @param urn The urn to create this urn from
+     * @param fragmentName The fragment name this urn should have
+     * @param instance Whether this urn should be a fragment
+     */
+    public ResourceUrn(ResourceUrn urn, String fragmentName, boolean instance) {
+        this(urn, new Name(fragmentName), instance);
+    }
+
+    /**
+     * Creates a urn with the module and resource name from the provided urn, but the fragment name provided.
+     * @param urn The urn to create this urn from
+     * @param fragmentName The fragment name this urn should have
+     * @param instance Whether this urn should be a fragment
+     */
+    public ResourceUrn(ResourceUrn urn, Name fragmentName, boolean instance) {
+        this.moduleName = urn.getModuleName();
+        this.resourceName = urn.getResourceName();
+        this.fragmentName = fragmentName;
+        this.instance = instance;
+    }
 
     /**
      * Creates a ModuleUri with the given module:resource combo

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/AssetTypeTest.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/AssetTypeTest.java
@@ -63,11 +63,10 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
     @Test
     public void loadData() {
         TextData data = new TextData(TEXT_VALUE);
-        Text text = new Text(URN, data, assetType);
 
         assertFalse(assetType.isLoaded(URN));
         Text createdText = assetType.loadAsset(URN, data);
-        assertEquals(text, createdText);
+        assertEquals(TEXT_VALUE, createdText.getValue());
         assertTrue(assetType.isLoaded(URN));
     }
 
@@ -76,7 +75,7 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
         TextData data = new TextData(TEXT_VALUE);
 
         Text loadedText = assetType.loadAsset(URN, data);
-        Optional<Text> retrievedText = assetType.getAsset(URN);
+        Optional<? extends Text> retrievedText = assetType.getAsset(URN);
         assertEquals(loadedText, retrievedText.get());
     }
 
@@ -175,7 +174,7 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
         when(producer.redirect(URN)).thenReturn(URN);
         when(producer.getAssetData(URN)).thenReturn(Optional.of(new TextData(TEXT_VALUE)));
 
-        Optional<Text> asset = assetType.getAsset(URN);
+        Optional<? extends Text> asset = assetType.getAsset(URN);
         assertTrue(asset.isPresent());
         assertEquals(URN, asset.get().getUrn());
         assertEquals(TEXT_VALUE, asset.get().getValue());
@@ -383,10 +382,11 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
         TextData data = new TextData(TEXT_VALUE);
 
         Text loadedText = assetType.loadAsset(URN, data);
-        Text newText = loadedText.createInstance();
+        Optional<Text> newText = loadedText.createInstance();
+        assertTrue(newText.isPresent());
         assetType.close();
         assertTrue(assetType.isClosed());
-        assertTrue(newText.isDisposed());
+        assertTrue(newText.get().isDisposed());
     }
 
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/book/Book.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/book/Book.java
@@ -21,6 +21,8 @@ import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
 
+import java.util.Optional;
+
 /**
  * @author Immortius
  */
@@ -34,8 +36,9 @@ public class Book extends Asset<BookData> {
     }
 
     @Override
-    protected Asset<BookData> doCreateInstance(ResourceUrn instanceUrn, AssetType<?, BookData> parentAssetType) {
-        return new Book(instanceUrn, new BookData(lines), parentAssetType);
+    protected Optional<? extends Asset<BookData>> doCreateCopy(ResourceUrn instanceUrn, AssetType<?, BookData> parentAssetType) {
+        return Optional.of(new Book(instanceUrn, new BookData(lines), parentAssetType))
+                ;
     }
 
     @Override

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionAsset.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionAsset.java
@@ -21,6 +21,8 @@ import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.module.annotations.RegisterAssetType;
 
+import java.util.Optional;
+
 /**
  * @author Immortius
  */
@@ -34,8 +36,8 @@ public class ExtensionAsset extends Asset<ExtensionData> {
     }
 
     @Override
-    protected Asset<ExtensionData> doCreateInstance(ResourceUrn instanceUrn, AssetType<?, ExtensionData> parentAssetType) {
-        return new ExtensionAsset(instanceUrn, new ExtensionData(value), parentAssetType);
+    protected Optional<? extends Asset<ExtensionData>> doCreateCopy(ResourceUrn instanceUrn, AssetType<?, ExtensionData> parentAssetType) {
+        return Optional.of(new ExtensionAsset(instanceUrn, new ExtensionData(value), parentAssetType));
     }
 
     @Override

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/AlternateAsset.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/AlternateAsset.java
@@ -20,6 +20,8 @@ import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
 
+import java.util.Optional;
+
 /**
  * @author Immortius
  */
@@ -30,8 +32,8 @@ public class AlternateAsset extends ParentAsset<AlternateAssetData> {
     }
 
     @Override
-    protected Asset<AlternateAssetData> doCreateInstance(ResourceUrn instanceUrn, AssetType<?, AlternateAssetData> parentAssetType) {
-        return new AlternateAsset(instanceUrn, new AlternateAssetData(), parentAssetType);
+    protected Optional<? extends Asset<AlternateAssetData>> doCreateCopy(ResourceUrn instanceUrn, AssetType<?, AlternateAssetData> parentAssetType) {
+        return Optional.of(new AlternateAsset(instanceUrn, new AlternateAssetData(), parentAssetType));
     }
 
     @Override

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/ChildAsset.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/ChildAsset.java
@@ -20,6 +20,8 @@ import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
 
+import java.util.Optional;
+
 /**
  * @author Immortius
  */
@@ -31,8 +33,8 @@ public class ChildAsset extends ParentAsset<ChildAssetData> {
     }
 
     @Override
-    protected Asset<ChildAssetData> doCreateInstance(ResourceUrn instanceUrn, AssetType<?, ChildAssetData> parentAssetType) {
-        return new ChildAsset(instanceUrn, new ChildAssetData(), parentAssetType);
+    protected Optional<? extends Asset<ChildAssetData>> doCreateCopy(ResourceUrn instanceUrn, AssetType<?, ChildAssetData> parentAssetType) {
+        return Optional.of(new ChildAsset(instanceUrn, new ChildAssetData(), parentAssetType));
     }
 
     @Override

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/text/Text.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/text/Text.java
@@ -20,6 +20,8 @@ import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
 import org.terasology.assets.ResourceUrn;
 
+import java.util.Optional;
+
 /**
  * @author Immortius
  */
@@ -33,8 +35,8 @@ public class Text extends Asset<TextData> {
     }
 
     @Override
-    protected Asset<TextData> doCreateInstance(ResourceUrn instanceUrn, AssetType<?, TextData> parentAssetType) {
-        return new Text(instanceUrn, new TextData(value), parentAssetType);
+    protected Optional<? extends Asset<TextData>> doCreateCopy(ResourceUrn copyUrn, AssetType<?, TextData> parentAssetType) {
+        return Optional.of(new Text(copyUrn, new TextData(value), parentAssetType));
     }
 
     @Override


### PR DESCRIPTION
* Reworked support for creating asset instances. Assets now have the option to provide a copy method, and if they do not it falls back on reloading the asset data and creating an instance based on that.
* Tweaked asset registration into the type to be more robust
* ResourceUrn is now a little more permissive as to what the module name and fragment name can contain.