### PR TITLE
Support for warn-only permission checks

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/AssetFactory.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/AssetFactory.java
@@ -36,5 +36,5 @@ public interface AssetFactory<T extends Asset<U>, U extends AssetData> {
      * @param data The data for the asset
      * @return The built asset
      */
-    T build(ResourceUrn urn, AssetType<T, U> assetType, U data);
+    T build(ResourceUrn urn, AssetType<? super T, U> assetType, U data);
 }

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/AssetType.java
@@ -62,7 +62,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
 
     private final Class<T> assetClass;
     private final Class<U> assetDataClass;
-    private final AssetFactory<T, U> factory;
+    private final AssetFactory<? extends T, U> factory;
     private final List<AssetDataProducer<U>> producers = Lists.newCopyOnWriteArrayList();
     private final Map<ResourceUrn, T> loadedAssets = new MapMaker().concurrencyLevel(4).makeMap();
     private final ListMultimap<ResourceUrn, T> instanceAssets = Multimaps.synchronizedListMultimap(ArrayListMultimap.<ResourceUrn, T>create());
@@ -83,7 +83,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param factory    The factory used to convert AssetData to Assets for this type
      */
     @SuppressWarnings("unchecked")
-    public AssetType(Class<T> assetClass, AssetFactory<T, U> factory) {
+    public AssetType(Class<T> assetClass, AssetFactory<? extends T, U> factory) {
         Preconditions.checkNotNull(assetClass);
         Preconditions.checkNotNull(factory);
 
@@ -497,6 +497,13 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      */
     public Set<ResourceUrn> getLoadedAssetUrns() {
         return ImmutableSet.copyOf(loadedAssets.keySet());
+    }
+
+    /**
+     * @return A list of all the loaded assets.
+     */
+    public Set<T> getLoadedAssets() {
+        return ImmutableSet.copyOf(loadedAssets.values());
     }
 
     /**

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAssetDataProducer.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAssetDataProducer.java
@@ -808,21 +808,21 @@ public class ModuleAssetDataProducer<U extends AssetData> implements AssetDataPr
             return Optional.of(new AssetPathWatcher(target, module, providingModule, getWatchService()));
         }
 
-        private ResourceUrn getResourceUrn(Path target, Collection<? extends FileFormat> formats) {
+        private Optional<ResourceUrn> getResourceUrn(Path target, Collection<? extends FileFormat> formats) {
             Path filename = target.getFileName();
             if (filename != null) {
                 for (FileFormat fileFormat : formats) {
                     if (fileFormat.getFileMatcher().matches(target)) {
                         try {
                             Name assetName = fileFormat.getAssetName(filename.toString());
-                            return new ResourceUrn(module, assetName);
+                            return Optional.of(new ResourceUrn(module, assetName));
                         } catch (InvalidAssetFilenameException e) {
                             logger.debug("Modified file does not have a valid asset name - '{}'", filename);
                         }
                     }
                 }
             }
-            return null;
+            return Optional.empty();
         }
 
         @Override
@@ -838,12 +838,12 @@ public class ModuleAssetDataProducer<U extends AssetData> implements AssetDataPr
 
         @Override
         protected void onFileModified(Path target, Set<ResourceUrn> outChanged) {
-            ResourceUrn urn = getResourceUrn(target, assetFormats);
-            if (urn == null) {
+            Optional<ResourceUrn> urn = getResourceUrn(target, assetFormats);
+            if (!urn.isPresent()) {
                 urn = getResourceUrn(target, supplementFormats);
             }
-            if (urn != null && unloadedAssetLookup.get(urn).isValid()) {
-                outChanged.add(urn);
+            if (urn.isPresent() && unloadedAssetLookup.get(urn.get()).isValid()) {
+                outChanged.add(urn.get());
             }
         }
 

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAwareAssetTypeManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAwareAssetTypeManager.java
@@ -138,7 +138,7 @@ public class ModuleAwareAssetTypeManager implements AssetTypeManager {
      * @param <T>            The type of asset
      * @param <U>            The type of asset data
      */
-    public synchronized <T extends Asset<U>, U extends AssetData> void registerCoreAssetType(Class<T> type, AssetFactory<T, U> factory, String... subfolderNames) {
+    public synchronized <T extends Asset<U>, U extends AssetData> void registerCoreAssetType(Class<T> type, AssetFactory<? extends T, U> factory, String... subfolderNames) {
         Preconditions.checkState(!assetTypes.containsKey(type), "Asset type '" + type.getSimpleName() + "' already registered");
         AssetType<T, U> assetType = new AssetType<>(type, factory);
         coreAssetTypes.add(assetType);

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/AssetManagerTest.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/AssetManagerTest.java
@@ -35,6 +35,8 @@ import org.terasology.assets.test.stubs.text.Text;
 import org.terasology.assets.test.stubs.text.TextData;
 import org.terasology.assets.test.stubs.text.TextFactory;
 
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -82,17 +84,32 @@ public class AssetManagerTest {
     }
 
     @Test
-    public void getLoadedAssets() {
+    public void getLoadedAssetUrns() {
         textAssetType.loadAsset(ENGINE_TEST_URN, new TextData("moo"));
-        assertEquals(ImmutableSet.of(ENGINE_TEST_URN), assetManager.getLoadedAssets(Text.class));
+        assertEquals(ImmutableSet.of(ENGINE_TEST_URN), assetManager.getLoadedAssetUrns(Text.class));
+    }
+
+    @Test
+    public void getLoadedAssetUrnsCombinesInherited() {
+        childAssetType.loadAsset(ENGINE_TEST_URN, new ChildAssetData());
+        alternateAssetType.loadAsset(ENGINE_TEST2_URN, new AlternateAssetData());
+
+        assertEquals(ImmutableSet.of(ENGINE_TEST_URN, ENGINE_TEST2_URN), assetManager.getLoadedAssetUrns(ParentAsset.class));
+    }
+
+    @Test
+    public void getLoadedAssets() {
+        Text asset = textAssetType.loadAsset(ENGINE_TEST_URN, new TextData("moo"));
+        assertEquals(ImmutableSet.of(asset), assetManager.getLoadedAssets(Text.class));
     }
 
     @Test
     public void getLoadedAssetsCombinesInherited() {
-        childAssetType.loadAsset(ENGINE_TEST_URN, new ChildAssetData());
-        alternateAssetType.loadAsset(ENGINE_TEST2_URN, new AlternateAssetData());
-
-        assertEquals(ImmutableSet.of(ENGINE_TEST_URN, ENGINE_TEST2_URN), assetManager.getLoadedAssets(ParentAsset.class));
+        ChildAsset asset1 = childAssetType.loadAsset(ENGINE_TEST_URN, new ChildAssetData());
+        AlternateAsset asset2 = alternateAssetType.loadAsset(ENGINE_TEST2_URN, new AlternateAssetData());
+        Set<ParentAsset> expected = ImmutableSet.of(asset1, asset2);
+        Set<ParentAsset> actual = assetManager.getLoadedAssets(ParentAsset.class);
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/book/BookFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/book/BookFactory.java
@@ -26,7 +26,7 @@ import org.terasology.assets.ResourceUrn;
 public class BookFactory implements AssetFactory<Book, BookData> {
 
     @Override
-    public Book build(ResourceUrn urn, AssetType<Book, BookData> type, BookData data) {
+    public Book build(ResourceUrn urn, AssetType<? super Book, BookData> type, BookData data) {
         return new Book(urn, data, type);
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionFactory.java
@@ -26,7 +26,7 @@ import org.terasology.assets.ResourceUrn;
 public class ExtensionFactory implements AssetFactory<ExtensionAsset, ExtensionData> {
 
     @Override
-    public ExtensionAsset build(ResourceUrn urn, AssetType<ExtensionAsset, ExtensionData> type, ExtensionData data) {
+    public ExtensionAsset build(ResourceUrn urn, AssetType<? super ExtensionAsset, ExtensionData> type, ExtensionData data) {
         return new ExtensionAsset(urn, data, type);
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/AlternateAssetFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/AlternateAssetFactory.java
@@ -25,7 +25,7 @@ import org.terasology.assets.ResourceUrn;
  */
 public class AlternateAssetFactory implements AssetFactory<AlternateAsset, AlternateAssetData> {
     @Override
-    public AlternateAsset build(ResourceUrn urn, AssetType<AlternateAsset, AlternateAssetData> type, AlternateAssetData data) {
+    public AlternateAsset build(ResourceUrn urn, AssetType<? super AlternateAsset, AlternateAssetData> type, AlternateAssetData data) {
         return new AlternateAsset(urn, data, type);
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/ChildAssetFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/ChildAssetFactory.java
@@ -25,7 +25,7 @@ import org.terasology.assets.ResourceUrn;
  */
 public class ChildAssetFactory implements AssetFactory<ChildAsset, ChildAssetData> {
     @Override
-    public ChildAsset build(ResourceUrn urn, AssetType<ChildAsset, ChildAssetData> type, ChildAssetData data) {
+    public ChildAsset build(ResourceUrn urn, AssetType<? super ChildAsset, ChildAssetData> type, ChildAssetData data) {
         return new ChildAsset(urn, data, type);
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/text/TextFactory.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/text/TextFactory.java
@@ -25,7 +25,7 @@ import org.terasology.assets.ResourceUrn;
  */
 public class TextFactory implements AssetFactory<Text, TextData> {
     @Override
-    public Text build(ResourceUrn urn, AssetType<Text, TextData> type, TextData data) {
+    public Text build(ResourceUrn urn, AssetType<? super Text, TextData> type, TextData data) {
         return new Text(urn, data, type);
     }
 }

--- a/gestalt-module/src/main/java/org/terasology/module/sandbox/API.java
+++ b/gestalt-module/src/main/java/org/terasology/module/sandbox/API.java
@@ -32,5 +32,5 @@ public @interface API {
     /**
      * @return The permission sets that should be granted access to the marked class
      */
-    String[] permissionSet() default {ModuleSecurityManager.BASE_PERMISSION_SET};
+    String[] permissionSet() default {StandardPermissionProviderFactory.BASE_PERMISSION_SET};
 }

--- a/gestalt-module/src/main/java/org/terasology/module/sandbox/APIScanner.java
+++ b/gestalt-module/src/main/java/org/terasology/module/sandbox/APIScanner.java
@@ -26,10 +26,10 @@ import org.terasology.module.ModuleRegistry;
  */
 public class APIScanner {
 
-    private ModuleSecurityManager securityManager;
+    private StandardPermissionProviderFactory permissionProviderFactory;
 
-    public APIScanner(ModuleSecurityManager securityManager) {
-        this.securityManager = securityManager;
+    public APIScanner(StandardPermissionProviderFactory permissionProviderFactory) {
+        this.permissionProviderFactory = permissionProviderFactory;
     }
 
     /**
@@ -54,10 +54,10 @@ public class APIScanner {
     public void scan(Module module) {
         for (Class<?> apiClass : module.getReflectionsFragment().getTypesAnnotatedWith(API.class, true)) {
             for (String permissionSetId : apiClass.getAnnotation(API.class).permissionSet()) {
-                PermissionSet permissionSet = securityManager.getPermissionSet(permissionSetId);
+                PermissionSet permissionSet = permissionProviderFactory.getPermissionSet(permissionSetId);
                 if (permissionSet == null) {
                     permissionSet = new PermissionSet();
-                    securityManager.addPermissionSet(permissionSetId, permissionSet);
+                    permissionProviderFactory.addPermissionSet(permissionSetId, permissionSet);
                 }
                 if (apiClass.isSynthetic()) {
                     // This is a package-info

--- a/gestalt-module/src/main/java/org/terasology/module/sandbox/StandardPermissionProviderFactory.java
+++ b/gestalt-module/src/main/java/org/terasology/module/sandbox/StandardPermissionProviderFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.module.sandbox;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.module.Module;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A permission provider factory that gives each module permissions based on a number of permission sets, where each module has access to the
+ * default set of permissions and can request additional permission sets.
+ * @see org.terasology.module.sandbox.PermissionSet
+ * @author Immortius
+ */
+public class StandardPermissionProviderFactory implements PermissionProviderFactory {
+
+    public static final String BASE_PERMISSION_SET = "";
+    private static final Logger logger = LoggerFactory.getLogger(StandardPermissionProviderFactory.class);
+    private final Map<String, PermissionSet> permissionSets = Maps.newHashMap();
+
+    public StandardPermissionProviderFactory() {
+        permissionSets.put(BASE_PERMISSION_SET, new PermissionSet());
+    }
+
+    /**
+     * @return The base permission set, which all modules are granted
+     */
+    public PermissionSet getBasePermissionSet() {
+        return getPermissionSet(BASE_PERMISSION_SET);
+    }
+
+    /**
+     * @param name The name of the permission set
+     * @return The permission set with the given name, or null
+     */
+    public PermissionSet getPermissionSet(String name) {
+        return permissionSets.get(name);
+    }
+
+    /**
+     * Adds or replaces a permission set that modules can request
+     * @param name The name to give the permission set
+     * @param permissionSet A permission set to associate with the given name
+     */
+    public void addPermissionSet(String name, PermissionSet permissionSet) {
+        this.permissionSets.put(name, permissionSet);
+    }
+
+    @Override
+    public PermissionProvider createPermissionProviderFor(Module module) {
+        List<PermissionSet> grantedPermissionSets = Lists.newArrayList();
+        grantedPermissionSets.add(getBasePermissionSet());
+        for (String permissionSetId : module.getRequiredPermissions()) {
+            PermissionSet set = getPermissionSet(permissionSetId);
+            if (set != null) {
+                grantedPermissionSets.add(set);
+            } else {
+                logger.warn("Module '{}' requires unknown permission '{}'", module, permissionSetId);
+            }
+        }
+        return new SetUnionPermissionProvider(grantedPermissionSets);
+    }
+}

--- a/gestalt-module/src/main/java/org/terasology/module/sandbox/WarnOnlyProviderFactory.java
+++ b/gestalt-module/src/main/java/org/terasology/module/sandbox/WarnOnlyProviderFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.module.sandbox;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.module.Module;
+
+import java.security.Permission;
+
+/**
+ * This provider factory wraps another factory. Whenever the other factory would deny access, this factory logs an error and grants permission.
+ * <p>This is intended to allow code being developed to run regardless of permission issues, so that required permissions can be gathered.</p>
+ * @author Immortius
+ */
+public class WarnOnlyProviderFactory implements PermissionProviderFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(WarnOnlyProviderFactory.class);
+    private PermissionProviderFactory wrappedFactory;
+
+    /**
+     * @param wrappedFactory Another permission factory to wrap.
+     */
+    public WarnOnlyProviderFactory(PermissionProviderFactory wrappedFactory) {
+        this.wrappedFactory = wrappedFactory;
+    }
+
+    @Override
+    public PermissionProvider createPermissionProviderFor(Module module) {
+        return new PermissionProvider() {
+
+            private PermissionProvider wrapped = wrappedFactory.createPermissionProviderFor(module);
+
+            @Override
+            public boolean isPermitted(Class type) {
+                if (!wrapped.isPermitted(type)) {
+                    logger.error("Use of non-permitted class '{}' detected by module '{}': this should be fixed for production use", type.toString(), module);
+                }
+                return true;
+            }
+
+            @Override
+            public boolean isPermitted(Permission permission, Class<?> context) {
+                if (!wrapped.isPermitted(permission, context)) {
+                    logger.error("Non-permitted permission '{}' required by module '{}', class '{}': this should be fixed for production use", permission, module, context);
+                }
+                return true;
+            }
+        };
+    }
+}

--- a/gestalt-module/src/test/java/org/terasology/module/sandbox/APIScannerTest.java
+++ b/gestalt-module/src/test/java/org/terasology/module/sandbox/APIScannerTest.java
@@ -41,11 +41,11 @@ public class APIScannerTest {
         metadata.setVersion(new Version("1.0.0"));
         Module module = ClasspathModule.create(metadata, true, getClass());
 
-        ModuleSecurityManager manager = mock(ModuleSecurityManager.class);
+        StandardPermissionProviderFactory permissionProviderFactory = mock(StandardPermissionProviderFactory.class);
         PermissionSet permSet = new PermissionSet();
-        when(manager.getPermissionSet(any(String.class))).thenReturn(permSet);
+        when(permissionProviderFactory.getPermissionSet(any(String.class))).thenReturn(permSet);
 
-        new APIScanner(manager).scan(module);
+        new APIScanner(permissionProviderFactory).scan(module);
         assertTrue(permSet.isPermitted(APIClass.class));
         assertFalse(permSet.isPermitted(NonAPIClassInheritingAPIClass.class));
     }


### PR DESCRIPTION
Tweaks to the use of generics in gestalt-asset-core.
Added a method for retrieving all the loaded assets (rather than the loaded asset urns)
Decoupled ModuleSecurityManager from the PermissionProviderFactory.
Added a warn-only wrapper for a PermissionProviderFactory that logs permission checks that would fail but doesn't fail them.