### PR TITLE
Allow only dots in Version patterns

### DIFF
--- a/gestalt-module/src/main/java/org/terasology/naming/Version.java
+++ b/gestalt-module/src/main/java/org/terasology/naming/Version.java
@@ -33,7 +33,7 @@ public final class Version implements Comparable<Version> {
      * A default version of 1.0.0
      */
     public static final Version DEFAULT = new Version(1, 0, 0);
-    private static final Pattern VERSION_PATTERN = Pattern.compile("(0|[1-9][0-9]*).(0|[1-9][0-9]*).(0|[1-9][0-9]*)(-SNAPSHOT)?");
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-SNAPSHOT)?");
 
     private int major;
     private int minor;

--- a/gestalt-module/src/test/java/org/terasology/naming/VersionTest.java
+++ b/gestalt-module/src/test/java/org/terasology/naming/VersionTest.java
@@ -94,6 +94,11 @@ public class VersionTest {
     }
 
     @Test(expected = VersionParseException.class)
+    public void exceptionParsingMalformedSeparator() {
+        new Version("1,2,3");
+    }
+
+    @Test(expected = VersionParseException.class)
     public void exceptionParsingInvalidNumbers() {
         new Version("1.1.6a");
     }


### PR DESCRIPTION
This PR restricts the separators between the individual parts of `Version` to dots.