### PR TITLE
Addressing #18 - optional module support

### DIFF
--- a/gestalt-module/src/main/java/org/terasology/module/DependencyInfo.java
+++ b/gestalt-module/src/main/java/org/terasology/module/DependencyInfo.java
@@ -29,6 +29,7 @@ public class DependencyInfo {
     private Name id = new Name("");
     private Version minVersion = new Version(1, 0, 0);
     private Version maxVersion;
+    private boolean optional;
 
     public DependencyInfo() {
     }
@@ -37,6 +38,7 @@ public class DependencyInfo {
         this.id = other.id;
         this.minVersion = other.minVersion;
         this.maxVersion = other.maxVersion;
+        this.optional = other.optional;
     }
 
     /**
@@ -66,6 +68,15 @@ public class DependencyInfo {
             return minVersion.getNextMajorVersion();
         }
         return maxVersion;
+    }
+
+    /**
+     * An optional dependency does not need to be present for a module with the dependency to be used. If it is present, it must fall within
+     * the allowed version range.
+     * @return Whether this dependency is optional
+     */
+    public boolean isOptional() {
+        return optional;
     }
 
     /**
@@ -100,5 +111,14 @@ public class DependencyInfo {
      */
     public void setMaxVersion(Version value) {
         this.maxVersion = value;
+    }
+
+    /**
+     * Sets whether the dependency is optional
+     *
+     * @param optional Whether this dependency should be optional
+     */
+    public void setOptional(boolean optional) {
+        this.optional = optional;
     }
 }

--- a/gestalt-module/src/main/java/org/terasology/module/DependencyResolver.java
+++ b/gestalt-module/src/main/java/org/terasology/module/DependencyResolver.java
@@ -20,10 +20,12 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import org.terasology.module.dependencyResolution.OptionalResolutionStrategy;
 import org.terasology.naming.Name;
 import org.terasology.naming.Version;
 import org.terasology.naming.VersionRange;
@@ -34,9 +36,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Dependency Resolver determines a working set of modules for a given set of desired modules. Where multiple versions are compatible, they are resolved in favour of the
@@ -49,17 +54,29 @@ import java.util.Set;
  * @author Immortius
  */
 public class DependencyResolver {
+    private final OptionalResolutionStrategy optionalStrategy;
     private final ModuleRegistry registry;
     private Set<Name> rootModules;
-    private SetMultimap<Name, Version> moduleVersionPool;
+    private SetMultimap<Name, PossibleVersion> moduleVersionPool;
     private ListMultimap<Name, Constraint> constraints;
     private UniqueQueue<Constraint> constraintQueue;
 
     /**
+     * Creates a DependencyResolver using the {@link org.terasology.module.dependencyResolution.OptionalResolutionStrategy#INCLUDE_IF_REQUIRED}.
+     *
      * @param registry The registry to resolve modules from
      */
     public DependencyResolver(ModuleRegistry registry) {
+        this(registry, OptionalResolutionStrategy.INCLUDE_IF_REQUIRED);
+    }
+
+    /**
+     * @param registry                   The registry to resolve modules from
+     * @param optionalResolutionStrategy The strategy for handling optional dependencies
+     */
+    public DependencyResolver(ModuleRegistry registry, OptionalResolutionStrategy optionalResolutionStrategy) {
         this.registry = registry;
+        this.optionalStrategy = optionalResolutionStrategy;
     }
 
     /**
@@ -109,10 +126,11 @@ public class DependencyResolver {
         while (!moduleQueue.isEmpty()) {
             Name id = moduleQueue.pop();
             for (Module version : registry.getModuleVersions(id)) {
-                moduleVersionPool.put(id, version.getVersion());
+                moduleVersionPool.put(id, new PossibleVersion(version.getVersion()));
                 for (DependencyInfo dependency : version.getMetadata().getDependencies()) {
                     if (involvedModules.add(dependency.getId())) {
                         moduleQueue.push(dependency.getId());
+                        moduleVersionPool.put(dependency.getId(), PossibleVersion.OPTIONAL_VERSION);
                     }
                 }
             }
@@ -128,22 +146,23 @@ public class DependencyResolver {
         for (Name name : moduleVersionPool.keySet()) {
             Set<Name> dependencies = Sets.newLinkedHashSet();
             for (Module module : registry.getModuleVersions(name)) {
-                for (DependencyInfo dependency : module.getMetadata().getDependencies()) {
-                    dependencies.add(dependency.getId());
-                }
+                dependencies.addAll(module.getMetadata().getDependencies().stream().map(DependencyInfo::getId).collect(Collectors.toList()));
             }
 
             for (Name dependency : dependencies) {
-                Map<Version, VersionRange> constraintTable = Maps.newHashMapWithExpectedSize(moduleVersionPool.get(name).size());
-                for (Version version : moduleVersionPool.get(name)) {
-                    Module versionedModule = registry.getModule(name, version);
-                    DependencyInfo info = versionedModule.getMetadata().getDependencyInfo(dependency);
-                    if (info != null) {
-                        constraintTable.put(version, info.versionRange());
+                Map<Version, CompatibleVersions> constraintTable = Maps.newHashMapWithExpectedSize(moduleVersionPool.get(name).size());
+                for (PossibleVersion version : moduleVersionPool.get(name)) {
+                    if (version.getVersion().isPresent()) {
+                        Module versionedModule = registry.getModule(name, version.getVersion().get());
+                        DependencyInfo info = versionedModule.getMetadata().getDependencyInfo(dependency);
+                        if (info != null) {
+                            constraintTable.put(version.getVersion().get(), new CompatibleVersions(info.versionRange(), info.isOptional() && !optionalStrategy.isRequired()));
+                        }
                     }
                 }
-                constraints.put(name, new Constraint(name, dependency, constraintTable));
-                constraints.put(dependency, new Constraint(name, dependency, constraintTable));
+                Constraint constraint = new VersionConstraint(name, dependency, constraintTable);
+                constraints.put(name, constraint);
+                constraints.put(dependency, constraint);
             }
         }
     }
@@ -165,7 +184,7 @@ public class DependencyResolver {
             Constraint constraint = constraintQueue.remove();
 
             if (applyConstraintToDependency(constraint)) {
-                for (Constraint relatedConstraint : constraints.get(constraint.to)) {
+                for (Constraint relatedConstraint : constraints.get(constraint.getTo())) {
                     if (!Objects.equals(relatedConstraint, constraint)) {
                         constraintQueue.add(relatedConstraint);
                     }
@@ -173,7 +192,7 @@ public class DependencyResolver {
             }
 
             if (applyConstraintToDependant(constraint)) {
-                for (Constraint relatedConstraint : constraints.get(constraint.from)) {
+                for (Constraint relatedConstraint : constraints.get(constraint.getFrom())) {
                     constraintQueue.add(relatedConstraint);
                 }
             }
@@ -192,24 +211,7 @@ public class DependencyResolver {
      * @return Whether a change was applied the "to" domain of the constraint.
      */
     private boolean applyConstraintToDependency(Constraint constraint) {
-        boolean changed = false;
-        Iterator<Version> dependencyVersions = moduleVersionPool.get(constraint.to).iterator();
-        while (dependencyVersions.hasNext()) {
-            Version dependencyVersion = dependencyVersions.next();
-            boolean valid = false;
-            for (Version version : moduleVersionPool.get(constraint.from)) {
-                VersionRange versionRange = constraint.getVersionCompatibilities().get(version);
-                if (versionRange == null || versionRange.contains(dependencyVersion)) {
-                    valid = true;
-                    break;
-                }
-            }
-            if (!valid) {
-                dependencyVersions.remove();
-                changed = true;
-            }
-        }
-        return changed;
+        return constraint.constrainTo(Collections.unmodifiableSet(moduleVersionPool.get(constraint.getFrom())), moduleVersionPool.get(constraint.getTo()));
     }
 
     /**
@@ -220,26 +222,7 @@ public class DependencyResolver {
      * @return Whether a change was applied to the "from" domain of the constraint
      */
     private boolean applyConstraintToDependant(Constraint constraint) {
-        boolean changed = false;
-        Iterator<Version> validVersions = moduleVersionPool.get(constraint.from).iterator();
-        while (validVersions.hasNext()) {
-            Version version = validVersions.next();
-            VersionRange versionRange = constraint.getVersionCompatibilities().get(version);
-            if (versionRange != null) {
-                boolean valid = false;
-                for (Version dependencyVersion : moduleVersionPool.get(constraint.to)) {
-                    if (versionRange.contains(dependencyVersion)) {
-                        valid = true;
-                        break;
-                    }
-                }
-                if (!valid) {
-                    validVersions.remove();
-                    changed = true;
-                }
-            }
-        }
-        return changed;
+        return constraint.constrainFrom(moduleVersionPool.get(constraint.getFrom()), Collections.unmodifiableSet(moduleVersionPool.get(constraint.getTo())));
     }
 
     /**
@@ -256,7 +239,8 @@ public class DependencyResolver {
         Set<Module> finalModuleSet = Sets.newLinkedHashSetWithExpectedSize(moduleVersionPool.keySet().size());
         Deque<Module> moduleQueue = Queues.newArrayDeque();
         for (Name rootModule : rootModules) {
-            Module module = registry.getModule(rootModule, reduceToLatestVersion(rootModule));
+            Version latestVersion = reduceToFinalVersion(rootModule, true).get();
+            Module module = registry.getModule(rootModule, latestVersion);
             finalModuleSet.add(module);
             moduleQueue.push(module);
         }
@@ -264,9 +248,12 @@ public class DependencyResolver {
         while (!moduleQueue.isEmpty()) {
             Module module = moduleQueue.pop();
             for (DependencyInfo dependency : module.getMetadata().getDependencies()) {
-                Module dependencyModule = registry.getModule(dependency.getId(), reduceToLatestVersion(dependency.getId()));
-                if (finalModuleSet.add(dependencyModule)) {
-                    moduleQueue.push(dependencyModule);
+                Optional<Version> latestVersion = reduceToFinalVersion(dependency.getId(), optionalStrategy.isDesired());
+                if (latestVersion.isPresent()) {
+                    Module dependencyModule = registry.getModule(dependency.getId(), latestVersion.get());
+                    if (finalModuleSet.add(dependencyModule)) {
+                        moduleQueue.push(dependencyModule);
+                    }
                 }
             }
         }
@@ -281,43 +268,117 @@ public class DependencyResolver {
      * @param module The module to limit to the latest version
      * @return The latest version of the module.
      */
-    private Version reduceToLatestVersion(Name module) {
-        if (moduleVersionPool.get(module).size() > 1) {
-            Iterator<Version> versions = moduleVersionPool.get(module).iterator();
-            Version latest = versions.next();
-            while (versions.hasNext()) {
-                Version version = versions.next();
-                if (version.compareTo(latest) > 0) {
-                    latest = version;
+    private Optional<Version> reduceToFinalVersion(Name module, boolean includeIfOptional) {
+        switch (moduleVersionPool.get(module).size()) {
+            case 0:
+                return Optional.empty();
+            case 1:
+                return moduleVersionPool.get(module).iterator().next().getVersion();
+            default:
+                PossibleVersion version;
+                if (!includeIfOptional && moduleVersionPool.get(module).contains(PossibleVersion.OPTIONAL_VERSION)) {
+                    version = PossibleVersion.OPTIONAL_VERSION;
+                } else {
+                    List<PossibleVersion> versions = Lists.newArrayList(moduleVersionPool.get(module));
+                    Collections.sort(versions);
+                    version = versions.get(versions.size() - 1);
                 }
-            }
-            moduleVersionPool.replaceValues(module, Arrays.asList(latest));
-            constraintQueue.addAll(constraints.get(module));
-            processConstraints();
-            return latest;
-        } else {
-            Iterator<Version> iterator = moduleVersionPool.get(module).iterator();
-            assert iterator.hasNext();
-            return iterator.next();
+                moduleVersionPool.replaceValues(module, Arrays.asList(version));
+                constraintQueue.addAll(constraints.get(module));
+                processConstraints();
+                return version.getVersion();
         }
     }
 
     /**
      * Describes a constraint, in the form of a mapping of Versions of the "from" module to allowed ranges of the "to" modules.
      */
-    private static final class Constraint {
+    private interface Constraint {
+
+        Name getFrom();
+
+        Name getTo();
+
+        boolean constrainFrom(Set<PossibleVersion> fromVersions, Set<PossibleVersion> toVersions);
+
+        boolean constrainTo(Set<PossibleVersion> fromVersions, Set<PossibleVersion> toVersions);
+
+    }
+
+    /**
+     * Describes a constraint, in the form of a mapping of Versions of the "from" module to allowed ranges of the "to" modules.
+     */
+    private static final class VersionConstraint implements Constraint {
         private final Name from;
         private final Name to;
-        private final Map<Version, VersionRange> versionCompatibilities;
+        private final Map<Version, CompatibleVersions> versionCompatibilities;
 
-        private Constraint(Name from, Name to, Map<Version, VersionRange> versionCompatibilities) {
+        private VersionConstraint(Name from, Name to, Map<Version, CompatibleVersions> versionCompatibilities) {
             this.from = from;
             this.to = to;
             this.versionCompatibilities = versionCompatibilities;
         }
 
-        public Map<Version, VersionRange> getVersionCompatibilities() {
-            return versionCompatibilities;
+        @Override
+        public Name getFrom() {
+            return from;
+        }
+
+        @Override
+        public Name getTo() {
+            return to;
+        }
+
+        @Override
+        public boolean constrainFrom(Set<PossibleVersion> fromVersions, Set<PossibleVersion> toVersions) {
+            boolean changed = false;
+            Iterator<PossibleVersion> validVersions = fromVersions.iterator();
+            while (validVersions.hasNext()) {
+                PossibleVersion version = validVersions.next();
+                if (version.getVersion().isPresent()) {
+                    CompatibleVersions compatibility = versionCompatibilities.get(version.getVersion().get());
+                    if (compatibility != null) {
+                        boolean valid = false;
+                        for (PossibleVersion dependencyVersion : toVersions) {
+                            if (compatibility.isCompatible(dependencyVersion)) {
+                                valid = true;
+                                break;
+                            }
+                        }
+                        if (!valid) {
+                            validVersions.remove();
+                            changed = true;
+                        }
+                    }
+                }
+            }
+            return changed;
+        }
+
+        @Override
+        public boolean constrainTo(Set<PossibleVersion> fromVersions, Set<PossibleVersion> toVersions) {
+            boolean changed = false;
+            Iterator<PossibleVersion> dependencyVersions = toVersions.iterator();
+            while (dependencyVersions.hasNext()) {
+                PossibleVersion dependencyVersion = dependencyVersions.next();
+                boolean valid = false;
+                for (PossibleVersion version : fromVersions) {
+                    if (version.getVersion().isPresent()) {
+                        CompatibleVersions compatibility = versionCompatibilities.get(version.getVersion().get());
+                        if (compatibility == null || compatibility.isCompatible(dependencyVersion)) {
+                            valid = true;
+                            break;
+                        }
+                    } else {
+                        valid = true;
+                    }
+                }
+                if (!valid) {
+                    dependencyVersions.remove();
+                    changed = true;
+                }
+            }
+            return changed;
         }
 
         @Override
@@ -325,8 +386,8 @@ public class DependencyResolver {
             if (obj == this) {
                 return true;
             }
-            if (obj instanceof Constraint) {
-                Constraint other = (Constraint) obj;
+            if (obj instanceof VersionConstraint) {
+                VersionConstraint other = (VersionConstraint) obj;
                 return Objects.equals(from, other.from) && Objects.equals(to, other.to);
             }
             return false;
@@ -340,6 +401,74 @@ public class DependencyResolver {
         @Override
         public String toString() {
             return from + "==>" + to;
+        }
+
+
+    }
+
+    private static class CompatibleVersions {
+        private final VersionRange versionRange;
+        private final boolean missingAllowed;
+
+        public CompatibleVersions(VersionRange versionRange, boolean missingAllowed) {
+            this.versionRange = versionRange;
+            this.missingAllowed = missingAllowed;
+        }
+
+        public boolean isCompatible(PossibleVersion version) {
+            if (version.getVersion().isPresent()) {
+                return versionRange.contains(version.getVersion().get());
+            } else {
+                return missingAllowed;
+            }
+        }
+    }
+
+    private static class PossibleVersion implements Comparable<PossibleVersion> {
+        public static final PossibleVersion OPTIONAL_VERSION = new PossibleVersion();
+        private final Optional<Version> version;
+
+        private PossibleVersion() {
+            version = Optional.empty();
+        }
+
+        public PossibleVersion(Version version) {
+            this.version = Optional.of(version);
+        }
+
+        public Optional<Version> getVersion() {
+            return version;
+        }
+
+        @Override
+        public int compareTo(PossibleVersion o) {
+            if (!version.isPresent()) {
+                if (o.version.isPresent()) {
+                    return -1;
+                }
+                return 0;
+            } else {
+                if (o.version.isPresent()) {
+                    return version.get().compareTo(o.version.get());
+                }
+                return 1;
+            }
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj instanceof PossibleVersion) {
+                return compareTo((PossibleVersion) obj) == 0;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(version);
         }
     }
 

--- a/gestalt-module/src/main/java/org/terasology/module/dependencyResolution/OptionalResolutionStrategy.java
+++ b/gestalt-module/src/main/java/org/terasology/module/dependencyResolution/OptionalResolutionStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.module.dependencyResolution;
+
+/**
+ * OptionalResolutionStrategy determines how optional dependencies are resolved by the dependency resolver.
+ *
+ * @author Immortius
+ */
+public enum OptionalResolutionStrategy {
+    /**
+     * Causes optional dependencies to be treated as mandatory dependencies.
+     */
+    FORCE_INCLUDE(true, true),
+
+    /**
+     * If an optional dependency is available it will be included, but missing optional dependency will not cause resolution failure.
+     */
+    INCLUDE_IF_AVAILABLE(false, true),
+
+    /**
+     * Optional dependencies will not be included unless otherwise required, but if present the version constraints will be applied
+     */
+    INCLUDE_IF_REQUIRED(false, false);
+
+    private final boolean required;
+    private final boolean desired;
+
+    private OptionalResolutionStrategy(boolean required, boolean desired) {
+        this.required = required;
+        this.desired = desired;
+    }
+
+    /**
+     * @return Whether an optional dependency must be provided
+     */
+    public boolean isRequired() {
+        return required;
+    }
+
+    /**
+     * @return Whether an optional dependency will be included if available
+     */
+    public boolean isDesired() {
+        return desired;
+    }
+}

--- a/gestalt-module/src/test/java/org/terasology/module/DependencyResolverTestBase.java
+++ b/gestalt-module/src/test/java/org/terasology/module/DependencyResolverTestBase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.module;
+
+import org.terasology.naming.Name;
+import org.terasology.naming.Version;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Immortius
+ */
+public class DependencyResolverTestBase {
+
+    protected void addDependency(Module dependant, String dependencyId) {
+        addDependency(dependant, dependencyId, false);
+    }
+
+    protected void addDependency(Module dependant, String dependencyId, boolean optional) {
+        DependencyInfo dependencyInfo = new DependencyInfo();
+        dependencyInfo.setId(new Name(dependencyId));
+        dependencyInfo.setOptional(optional);
+        dependant.getMetadata().getDependencies().add(dependencyInfo);
+    }
+
+    protected void addDependency(Module dependant, String dependencyId, String lowerbound, String upperbound, boolean optional) {
+        DependencyInfo dependencyInfo = new DependencyInfo();
+        dependencyInfo.setId(new Name(dependencyId));
+        dependencyInfo.setOptional(optional);
+        dependencyInfo.setMinVersion(new Version(lowerbound));
+        dependencyInfo.setMaxVersion(new Version(upperbound));
+        dependant.getMetadata().getDependencies().add(dependencyInfo);
+    }
+
+    protected void addDependency(Module dependant, String dependencyId, String lowerbound, String upperbound) {
+        DependencyInfo dependencyInfo = new DependencyInfo();
+        dependencyInfo.setId(new Name(dependencyId));
+        dependencyInfo.setMinVersion(new Version(lowerbound));
+        dependencyInfo.setMaxVersion(new Version(upperbound));
+        dependant.getMetadata().getDependencies().add(dependencyInfo);
+    }
+
+    protected Module createStubModule(ModuleRegistry forRegistry, String id, String version) {
+        Module module = mock(Module.class);
+        ModuleMetadata metadata = new ModuleMetadata();
+        when(module.getMetadata()).thenReturn(metadata);
+        when(module.getId()).thenReturn(new Name(id));
+        when(module.getVersion()).thenReturn(new Version(version));
+        forRegistry.add(module);
+        return module;
+    }
+}

--- a/gestalt-module/src/test/java/org/terasology/module/ForceIncludeOptionalDependencyResolverTest.java
+++ b/gestalt-module/src/test/java/org/terasology/module/ForceIncludeOptionalDependencyResolverTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.module;
+
+import com.google.common.collect.Sets;
+import org.junit.Test;
+import org.terasology.module.dependencyResolution.OptionalResolutionStrategy;
+import org.terasology.naming.Name;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Immortius
+ */
+public class ForceIncludeOptionalDependencyResolverTest extends DependencyResolverTestBase {
+
+    @Test
+    public void optionalRequired() {
+        ModuleRegistry registry = new TableModuleRegistry();
+        Module core = createStubModule(registry, "core", "1.0.0");
+        createStubModule(registry, "a", "1.0.0");
+
+        addDependency(core, "a");
+        addDependency(core, "b", true);
+
+        DependencyResolver resolver = new DependencyResolver(registry, OptionalResolutionStrategy.FORCE_INCLUDE);
+        ResolutionResult results = resolver.resolve(new Name("core"));
+        assertFalse(results.isSuccess());
+    }
+
+    @Test
+    public void optionalIncluded() {
+        ModuleRegistry registry = new TableModuleRegistry();
+        Module core = createStubModule(registry, "core", "1.0.0");
+        Module moduleA = createStubModule(registry, "a", "1.0.0");
+        Module moduleB = createStubModule(registry, "b", "1.0.0");
+
+        addDependency(core, "a");
+        addDependency(core, "b", true);
+
+        DependencyResolver resolver = new DependencyResolver(registry, OptionalResolutionStrategy.FORCE_INCLUDE);
+        ResolutionResult results = resolver.resolve(new Name("core"));
+        assertTrue(results.isSuccess());
+        assertEquals(Sets.newHashSet(core, moduleA, moduleB), results.getModules());
+    }
+
+}

--- a/gestalt-module/src/test/java/org/terasology/module/NormalDependencyResolverTest.java
+++ b/gestalt-module/src/test/java/org/terasology/module/NormalDependencyResolverTest.java
@@ -201,4 +201,43 @@ public class NormalDependencyResolverTest extends DependencyResolverTestBase {
         assertTrue(results.isSuccess());
         assertEquals(Sets.newHashSet(core, moduleA, moduleBLatest), results.getModules());
     }
+
+    @Test
+    public void optionalConstraintAppliedIfUsed() {
+        ModuleRegistry registry = new TableModuleRegistry();
+        Module core = createStubModule(registry, "core", "1.0.0");
+        Module moduleA = createStubModule(registry, "a", "1.0.0");
+        Module moduleB = createStubModule(registry, "b", "1.0.0");
+        Module moduleC = createStubModule(registry, "c", "1.0.0");
+        createStubModule(registry, "c", "2.0.0");
+
+        addDependency(core, "a");
+        addDependency(core, "b");
+        addDependency(moduleA, "c", "1.0.0", "3.0.0");
+        addDependency(moduleB, "c", "1.0.0", "2.0.0", true);
+
+        DependencyResolver resolver = new DependencyResolver(registry);
+        ResolutionResult results = resolver.resolve(new Name("core"));
+        assertTrue(results.isSuccess());
+        assertEquals(Sets.newHashSet(core, moduleA, moduleB, moduleC), results.getModules());
+    }
+
+    @Test
+    public void optionalConstraintCanCauseFailuresDueToConflict() {
+        ModuleRegistry registry = new TableModuleRegistry();
+        Module core = createStubModule(registry, "core", "1.0.0");
+        Module moduleA = createStubModule(registry, "a", "1.0.0");
+        Module moduleB = createStubModule(registry, "b", "1.0.0");
+        createStubModule(registry, "c", "1.0.0");
+        createStubModule(registry, "c", "2.0.0");
+
+        addDependency(core, "a");
+        addDependency(core, "b");
+        addDependency(moduleA, "c", "1.0.0", "2.0.0");
+        addDependency(moduleB, "c", "2.0.0", "3.0.0", true);
+
+        DependencyResolver resolver = new DependencyResolver(registry);
+        ResolutionResult results = resolver.resolve(new Name("core"));
+        assertFalse(results.isSuccess());
+    }
 }

--- a/gestalt-module/src/test/java/org/terasology/module/UseOptionalIfAvailableDependencyResolverTest.java
+++ b/gestalt-module/src/test/java/org/terasology/module/UseOptionalIfAvailableDependencyResolverTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.module;
+
+import com.google.common.collect.Sets;
+import org.junit.Test;
+import org.terasology.module.dependencyResolution.OptionalResolutionStrategy;
+import org.terasology.naming.Name;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Immortius
+ */
+public class UseOptionalIfAvailableDependencyResolverTest extends DependencyResolverTestBase {
+
+    @Test
+    public void optionalNotRequired() {
+        ModuleRegistry registry = new TableModuleRegistry();
+        Module core = createStubModule(registry, "core", "1.0.0");
+        Module moduleA = createStubModule(registry, "a", "1.0.0");
+
+        addDependency(core, "a");
+        addDependency(core, "b", true);
+
+        DependencyResolver resolver = new DependencyResolver(registry, OptionalResolutionStrategy.INCLUDE_IF_AVAILABLE);
+        ResolutionResult results = resolver.resolve(new Name("core"));
+        assertTrue(results.isSuccess());
+        assertEquals(Sets.newHashSet(core, moduleA), results.getModules());
+    }
+
+    @Test
+    public void optionalUsedIfAvailable() {
+        ModuleRegistry registry = new TableModuleRegistry();
+        Module core = createStubModule(registry, "core", "1.0.0");
+        Module moduleA = createStubModule(registry, "a", "1.0.0");
+        Module moduleB = createStubModule(registry, "b", "1.0.0");
+
+        addDependency(core, "a");
+        addDependency(core, "b", true);
+
+        DependencyResolver resolver = new DependencyResolver(registry, OptionalResolutionStrategy.INCLUDE_IF_AVAILABLE);
+        ResolutionResult results = resolver.resolve(new Name("core"));
+        assertTrue(results.isSuccess());
+        assertEquals(Sets.newHashSet(core, moduleA, moduleB), results.getModules());
+    }
+
+}


### PR DESCRIPTION
 * Adds optional flag to DependencyInfo
 * Supports three strategies for handling optionals:
    * Treat as mandatory
    * Include if available
    * Include only if otherwise required
 * Reworked the dependency resolver to treat "no version" as a version possibility
 * Encapsulated the contraint processing in the constraint class