### PR TITLE
Bug fixes and support for not reloading assets on environment switch

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/format/AssetDataFile.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/format/AssetDataFile.java
@@ -51,7 +51,6 @@ public class AssetDataFile {
      */
     public AssetDataFile(Path path) {
         Preconditions.checkNotNull(path);
-        Preconditions.checkArgument(Files.isRegularFile(path));
         this.path = path;
     }
 
@@ -97,13 +96,9 @@ public class AssetDataFile {
      * @throws IOException If there was an error opening the file
      */
     public BufferedInputStream openStream() throws IOException {
+        Preconditions.checkState(Files.isRegularFile(path));
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<BufferedInputStream>() {
-                @Override
-                public BufferedInputStream run() throws IOException {
-                    return new BufferedInputStream(Files.newInputStream(path));
-                }
-            });
+            return AccessController.doPrivileged((PrivilegedExceptionAction<BufferedInputStream>) () -> new BufferedInputStream(Files.newInputStream(path)));
         } catch (PrivilegedActionException e) {
             throw new IOException("Failed to open stream for '" + path + "'", e);
         }

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/management/AssetManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/management/AssetManager.java
@@ -237,7 +237,7 @@ public final class AssetManager {
         if (assetType.isPresent()) {
             return assetType.get().loadAsset(urn, data);
         } else {
-            throw new IllegalStateException(type + " is not a support type of asset");
+            throw new IllegalStateException(type + " is not a supported type of asset");
         }
     }
 

--- a/gestalt-module/src/main/java/org/terasology/module/filesystem/ModulePath.java
+++ b/gestalt-module/src/main/java/org/terasology/module/filesystem/ModulePath.java
@@ -509,7 +509,7 @@ class ModulePath implements Path {
      */
     static Path convertFromActualToModulePath(ModuleFileSystem fileSystem, Path root, Path actualPath) throws IOException {
         Path actualRealPath = actualPath.toRealPath();
-        Path relative = root.relativize(actualRealPath);
+        Path relative = root.toRealPath().relativize(actualRealPath);
         List<String> pathParts = Lists.newArrayListWithCapacity(relative.getNameCount() + 1);
         pathParts.add(ModuleFileSystemProvider.SEPARATOR);
         for (Path part : relative) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.2.4-SNAPSHOT
+version=3.2.1-SNAPSHOT


### PR DESCRIPTION
Added support for core asset types that don't reload on environment switch.

Fixed a number of bugs:
* Loading an asset is now done in a privileged access block.
* AssetDataFile now accepts non-existent paths for the purposes of equals.
* Fixed an issue with directory tree walking with a relative path.