### PR TITLE
Optimisation to asset change watching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.2.1-SNAPSHOT
+version=4.0.0-SNAPSHOT


### PR DESCRIPTION
Now ignores modules with no locations in the default file system (i.e no exploded directories)