### PR TITLE
Add modifiable iterator for TableModuleRegistry

### DIFF
--- a/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
@@ -18,7 +18,6 @@ package org.terasology.module;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
@@ -195,7 +194,31 @@ public class TableModuleRegistry implements ModuleRegistry {
 
     @Override
     public Iterator<Module> iterator() {
-        return Iterators.unmodifiableIterator(modules.values().iterator());
+        Iterator<Module> it = modules.values().iterator();
+        return new Iterator<Module>() {
+
+            private Module current;
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public Module next() {
+                current = it.next();
+                return current;
+            }
+
+            @Override
+            public void remove() {
+                it.remove();
+                Module latest = latestModules.get(current.getId());
+                if (latest.getVersion().compareTo(current.getVersion()) == 0) {
+                    updateLatestFor(current.getId());
+                }
+            }
+        };
     }
 
     @Override

--- a/gestalt-module/src/test/java/org/terasology/module/TableModuleRegistryTest.java
+++ b/gestalt-module/src/test/java/org/terasology/module/TableModuleRegistryTest.java
@@ -20,7 +20,9 @@ import org.junit.Test;
 import org.terasology.naming.Name;
 import org.terasology.naming.Version;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,5 +59,27 @@ public class TableModuleRegistryTest {
         when(moduleSnapshot.getVersion()).thenReturn(new Version(1, 0, 0, true));
         registry.add(moduleSnapshot);
         assertFalse(registry.getLatestModuleVersion(MODULE_NAME).getVersion().isSnapshot());
+    }
+
+    @Test
+    public void iteratorRemove() {
+        TableModuleRegistry registry = new TableModuleRegistry();
+        Module moduleV1 = mock(Module.class);
+        when(moduleV1.getId()).thenReturn(MODULE_NAME);
+        when(moduleV1.getVersion()).thenReturn(new Version(1, 0, 0));
+        registry.add(moduleV1);
+        Module moduleV2 = mock(Module.class);
+        when(moduleV2.getId()).thenReturn(MODULE_NAME);
+        when(moduleV2.getVersion()).thenReturn(new Version(2, 0, 0));
+        registry.add(moduleV2);
+
+        // remove entries based on their version
+        registry.removeIf(mod -> mod.getVersion().compareTo(new Version(1, 5, 0)) > 0);
+
+        assertEquals(new Version(1, 0, 0), registry.getLatestModuleVersion(MODULE_NAME).getVersion());
+
+        registry.removeIf(mod -> mod.getId().equals(MODULE_NAME));
+
+        assertTrue(registry.isEmpty());
     }
 }


### PR DESCRIPTION
Since `TableModuleRegistry` supports removing elements, I replaced the read-only iterator with a full implementation to achieve consistent behavior.

This allows for using iterator-based editing methods such as `removeIf()`.