### PR TITLE
Thread safety fix.

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAwareAssetTypeManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAwareAssetTypeManager.java
@@ -356,7 +356,6 @@ public class ModuleAwareAssetTypeManager implements AssetTypeManager, Closeable 
         if (watcher != null) {
             try {
                 watcher.shutdown();
-                watcher = null;
             } catch (IOException e) {
                 logger.error("Failed to shut down watch service", e);
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.3-SNAPSHOT
+version=4.1.1-SNAPSHOT


### PR DESCRIPTION
Fix for ModuleWatcher being closed and reopened as part of a module environment switch, while a second thread is continually checking for changed assets.