### PR TITLE
Improved asset disposal

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/Asset.java
@@ -17,8 +17,6 @@
 package org.terasology.assets;
 
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.module.sandbox.API;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -50,8 +48,6 @@ import java.util.Optional;
 @API
 @ThreadSafe
 public abstract class Asset<T extends AssetData> {
-
-    private static final Logger logger = LoggerFactory.getLogger(Asset.class);
 
     private final ResourceUrn urn;
     private final AssetType<?, T> assetType;
@@ -188,8 +184,7 @@ public abstract class Asset<T extends AssetData> {
     protected final void finalize() throws Throwable {
         super.finalize();
         if (!disposed) {
-            logger.warn("Asset '{}' not correctly disposed but garbage collected", urn);
-            dispose();
+            assetType.queueForDisposal(this);
         }
     }
 }

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/management/AssetTypeManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/management/AssetTypeManager.java
@@ -54,4 +54,10 @@ public interface AssetTypeManager {
     <T extends Asset<?>> List<AssetType<? extends T, ?>> getAssetTypes(Class<T> type);
 
 
+    /**
+     * Disposes any assets that are unused (not referenced)
+     */
+    void disposedUnusedAssets();
+
+
 }

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/management/MapAssetTypeManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/management/MapAssetTypeManager.java
@@ -66,6 +66,11 @@ public final class MapAssetTypeManager implements AssetTypeManager {
         return result;
     }
 
+    @Override
+    public void disposedUnusedAssets() {
+        assetTypes.values().forEach(type -> type.processDisposal());
+    }
+
     /**
      * Creates a new asset type for the given class of asset. There must not be an existing asset type for that class.
      *

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAwareAssetTypeManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAwareAssetTypeManager.java
@@ -156,6 +156,11 @@ public class ModuleAwareAssetTypeManager implements AssetTypeManager, Closeable 
         return result;
     }
 
+    @Override
+    public void disposedUnusedAssets() {
+        assetTypes.values().forEach(type -> type.processDisposal());
+    }
+
     /**
      * Triggers the reload of any assets that have been altered in directory modules.
      */


### PR DESCRIPTION
#29, #28
Unreferenced assets are now added to a disposal queue, and will be disposed upon request. This should allow for midgame release of unused assets, as well as addresses potential memory leaks via short lived assets that are not properly disposed. Particularly asset instances, which cannot be reobtained easily.