### PR TITLE
Fix AssetDataFile.toString()

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/format/AssetDataFile.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/format/AssetDataFile.java
@@ -106,7 +106,7 @@ public class AssetDataFile {
 
     @Override
     public String toString() {
-        return path.toUri().toString();
+        return path.toAbsolutePath().toString();
     }
 
     @Override


### PR DESCRIPTION
Currently, `AssetDataFile.toString()` attempts to convert the path to an URI. This does not always work, in particular not for [ModulePath.toUri()](https://github.com/MovingBlocks/gestalt/blob/develop/gestalt-module/src/main/java/org/terasology/module/filesystem/ModulePath.java#L274), which does not implement the said method.

I therefore suggest using the absolute path to avoid this issue.