### PR TITLE
Improved asset disposal on asset garbage collection

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/DisposalHook.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/DisposalHook.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.assets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Modifier;
+import java.util.Optional;
+
+/**
+ * Asset disposer is used to set the action to run at the
+ */
+public class DisposalHook {
+
+    private static final Logger logger = LoggerFactory.getLogger(DisposalHook.class);
+    private volatile Optional<Runnable> disposeAction = Optional.empty();
+
+    synchronized void dispose() {
+        if (disposeAction.isPresent()) {
+            disposeAction.get().run();
+        }
+        disposeAction = Optional.empty();
+    }
+
+    public void setDisposeAction(Runnable disposeAction) {
+        setDisposeAction(Optional.of(disposeAction));
+    }
+
+    public void setDisposeAction(Optional<Runnable> disposeAction) {
+        if (disposeAction.isPresent()) {
+            Class<? extends Runnable> actionType = disposeAction.get().getClass();
+            if ((actionType.isLocalClass() || actionType.isAnonymousClass() || actionType.isMemberClass()) && !Modifier.isStatic(actionType.getModifiers())) {
+                logger.warn("Non-static anonymous or member class should not be registered as the disposal hook - this will block garbage collection enqueuing for disposal");
+            }
+        }
+        this.disposeAction = disposeAction;
+    }
+}

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/book/Book.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/book/Book.java
@@ -17,8 +17,11 @@
 package org.terasology.assets.test.stubs.book;
 
 import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.assets.Asset;
 import org.terasology.assets.AssetType;
+import org.terasology.assets.DisposalHook;
 import org.terasology.assets.ResourceUrn;
 
 import java.util.Optional;
@@ -33,6 +36,7 @@ public class Book extends Asset<BookData> {
     public Book(ResourceUrn urn, BookData data, AssetType<?, BookData> type) {
         super(urn, type);
         reload(data);
+        getDisposalHook().setDisposeAction(new DisposalAction(urn));
     }
 
     @Override
@@ -45,12 +49,22 @@ public class Book extends Asset<BookData> {
         lines = ImmutableList.copyOf(data.getLines());
     }
 
-    @Override
-    protected void doDispose() {
-        lines = ImmutableList.of();
-    }
-
     public ImmutableList<String> getLines() {
         return lines;
+    }
+
+    private static class DisposalAction implements Runnable {
+
+        private static final Logger logger = LoggerFactory.getLogger(DisposalAction.class);
+        private ResourceUrn urn;
+
+        public DisposalAction(ResourceUrn urn) {
+            this.urn = urn;
+        }
+
+        @Override
+        public void run() {
+            logger.info("Disposed: {}", urn);
+        }
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionAsset.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionAsset.java
@@ -45,11 +45,6 @@ public class ExtensionAsset extends Asset<ExtensionData> {
         this.value = data.getValue();
     }
 
-    @Override
-    protected void doDispose() {
-
-    }
-
     public String getValue() {
         return value;
     }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/AlternateAsset.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/AlternateAsset.java
@@ -41,8 +41,4 @@ public class AlternateAsset extends ParentAsset<AlternateAssetData> {
 
     }
 
-    @Override
-    protected void doDispose() {
-
-    }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/ChildAsset.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/inheritance/ChildAsset.java
@@ -42,8 +42,4 @@ public class ChildAsset extends ParentAsset<ChildAssetData> {
 
     }
 
-    @Override
-    protected void doDispose() {
-
-    }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/text/Text.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/test/stubs/text/Text.java
@@ -44,10 +44,6 @@ public class Text extends Asset<TextData> {
         value = data.getValue();
     }
 
-    @Override
-    protected void doDispose() {
-    }
-
     public String getValue() {
         return value;
     }

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -8,7 +8,7 @@
 // Primary dependencies definition
 dependencies {
     compile project(":gestalt-util")
-    compile group: 'org.reflections', name: 'reflections', version: '0.9.9'
+    compile group: 'org.reflections', name: 'reflections', version: '0.9.10'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.3.1'
     compile group: 'dom4j', name : 'dom4j', version: '1.6.1'
     compile group: 'org.apache.commons', name : 'commons-vfs2', version: '2.0'


### PR DESCRIPTION
Switched to a PhantomReference based method for disposal of garbage collected assets.

This avoids the need for multiple garbage collection to fully collect assets.
With this change the Asset::onDispose() method is removed. Assets are now expected to register a static Runnable implementation with a provided DisposalHook, which will be run either when an asset is explicitly disposed, or if it is disposed after garbage collection via AssetType::processDisposal().