### PR TITLE
Add check for loaded assets in AssetManager

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/management/AssetManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/management/AssetManager.java
@@ -34,8 +34,8 @@ import java.util.Set;
 /**
  * AssetManager provides an simplified interface for working with assets across multiple asset types.
  * <p>
- * To do this it uses an AssetManager to obtain the AssetTypes relating to an Asset class of interest, and delegates down to them for actions such
- * as obtaining and reloading assets.
+ * To do this it uses an {@link AssetTypeManager} to obtain the AssetTypes relating to an Asset
+ * class of interest, and delegates down to them for actions such as obtaining and reloading assets.
  * </p>
  *
  * @author Immortius
@@ -46,6 +46,9 @@ public final class AssetManager {
 
     private final AssetTypeManager assetTypeManager;
 
+    /**
+     * @param assetTypeManager the asset type manager that will be used
+     */
     public AssetManager(AssetTypeManager assetTypeManager) {
         this.assetTypeManager = assetTypeManager;
     }

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/management/AssetManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/management/AssetManager.java
@@ -51,6 +51,20 @@ public final class AssetManager {
     }
 
     /**
+     * @param urn The urn of the asset to check. Must not be an instance urn
+     * @param type The Asset class of interest
+     * @return whether an asset is loaded with the given urn
+     */
+    public boolean isLoaded(ResourceUrn urn, Class<? extends Asset<?>> type) {
+        for (AssetType<?, ?> assetType : assetTypeManager.getAssetTypes(type)) {
+            if (assetType.isLoaded(urn)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Retrieves a set of the ResourceUrns for all loaded assets of the given Asset class (including subtypes)
      *
      * @param type The Asset class of interest

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/AssetManagerTest.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/AssetManagerTest.java
@@ -84,6 +84,14 @@ public class AssetManagerTest {
     }
 
     @Test
+    public void checkIfAssetIsLoaded() {
+        textAssetType.loadAsset(ENGINE_TEST_URN, new TextData("moo"));
+        assertFalse(assetManager.isLoaded(MORE_TEST_URN, Text.class));
+        assertFalse(assetManager.isLoaded(ENGINE_TEST_URN, AlternateAsset.class));
+        assertTrue(assetManager.isLoaded(ENGINE_TEST_URN, Text.class));
+    }
+
+    @Test
     public void getLoadedAssetUrns() {
         textAssetType.loadAsset(ENGINE_TEST_URN, new TextData("moo"));
         assertEquals(ImmutableSet.of(ENGINE_TEST_URN), assetManager.getLoadedAssetUrns(Text.class));


### PR DESCRIPTION
This PR adds a method `AssetManager.isloaded` that allows for testing whether an asset is currently loaded or not. Previously, this was only possible through `getLoadedAssetUrns`, which creates a copy of the entire set.

A unit test verifies all conditional branches.

Added some JavaDoc.