### PR TITLE
Bump library versions to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,12 @@ configure(subprojects.findAll { !it.name.contains("testpack") && !it.name.starts
 
     // Primary dependencies definition
     dependencies {
-        compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.13'
+        compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
         compile group: 'com.google.guava', name: 'guava', version: '19.0'
 
         // These dependencies are only needed for running tests
         testCompile group: 'junit', name: 'junit', version: '4.12'
-        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.3'
+        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
         testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     }
 


### PR DESCRIPTION
Use latest versions of logging libraries slf4j and logback.
The other libraries are up to date.