### PR TITLE
Disposal Notification Fix

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/Asset.java
@@ -126,8 +126,8 @@ public abstract class Asset<T extends AssetData> {
     public final synchronized void dispose() {
         if (!disposed) {
             disposed = true;
-            disposalHook.dispose();
             assetType.onAssetDisposed(this);
+            disposalHook.dispose();
         }
     }
 


### PR DESCRIPTION
Altered the order of disposal processing so that assets are removed from their type before disposal - this ensures that if a disposal action triggers a refetch of the asset the (being disposed) same asset isn't returned.