### PR TITLE
avoid snapshots being overridden

### DIFF
--- a/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
@@ -168,7 +168,7 @@ public class TableModuleRegistry implements ModuleRegistry {
                 Module result = null;
                 for (Map.Entry<Version, Module> item : modules.row(id).entrySet()) {
                     if (item.getKey().compareTo(minVersion) >= 0 && item.getKey().compareTo(maxVersion) < 0
-                        && (result == null || item.getKey().compareTo(result.getVersion()) > 0)) {
+                            && (result == null || item.getKey().compareTo(result.getVersion()) > 0)) {
                         result = item.getValue();
                     }
                 }

--- a/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
@@ -21,6 +21,8 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.naming.Name;
 import org.terasology.naming.Version;
 
@@ -37,6 +39,8 @@ import java.util.Set;
  */
 public class TableModuleRegistry implements ModuleRegistry {
 
+    private static final Logger LOG = LoggerFactory.getLogger(TableModuleRegistry.class);
+
     private final Table<Name, Version, Module> modules = HashBasedTable.create();
     private final Map<Name, Module> latestModules = Maps.newHashMap();
 
@@ -50,6 +54,12 @@ public class TableModuleRegistry implements ModuleRegistry {
                 latestModules.put(module.getId(), module);
             }
             return true;
+        } else {
+            LOG.error("Module {}-{} already registered from {}, cannot register same module from {}",
+                    module.getId(),
+                    module.getVersion(),
+                    modules.get(module.getId(), module.getVersion()).getLocations(),
+                    module.getLocations());
         }
         return false;
     }

--- a/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
@@ -39,7 +39,7 @@ import java.util.Set;
  */
 public class TableModuleRegistry implements ModuleRegistry {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TableModuleRegistry.class);
+    private static final Logger logger = LoggerFactory.getLogger(TableModuleRegistry.class);
 
     private final Table<Name, Version, Module> modules = HashBasedTable.create();
     private final Map<Name, Module> latestModules = Maps.newHashMap();
@@ -55,7 +55,7 @@ public class TableModuleRegistry implements ModuleRegistry {
             }
             return true;
         } else {
-            LOG.error("Module {}-{} already registered from {}, cannot register same module from {}",
+            logger.error("Module {}-{} already registered from {}, cannot register same module from {}",
                     module.getId(),
                     module.getVersion(),
                     modules.get(module.getId(), module.getVersion()).getLocations(),
@@ -168,7 +168,7 @@ public class TableModuleRegistry implements ModuleRegistry {
                 Module result = null;
                 for (Map.Entry<Version, Module> item : modules.row(id).entrySet()) {
                     if (item.getKey().compareTo(minVersion) >= 0 && item.getKey().compareTo(maxVersion) < 0
-                            && (result == null || item.getKey().compareTo(result.getVersion()) > 0)) {
+                        && (result == null || item.getKey().compareTo(result.getVersion()) > 0)) {
                         result = item.getValue();
                     }
                 }

--- a/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/module/TableModuleRegistry.java
@@ -43,7 +43,7 @@ public class TableModuleRegistry implements ModuleRegistry {
     @Override
     public boolean add(Module module) {
         Preconditions.checkNotNull(module);
-        if (!modules.contains(module.getId(), module.getVersion()) || modules.get(module.getId(), module.getVersion()).getVersion().isSnapshot()) {
+        if (!modules.contains(module.getId(), module.getVersion())) {
             modules.put(module.getId(), module.getVersion(), module);
             Module previousLatest = latestModules.get(module.getId());
             if (previousLatest == null || previousLatest.getVersion().compareTo(module.getVersion()) <= 0) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.1.2-SNAPSHOT
+version=5.1.3-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.1.3-SNAPSHOT
+version=5.1.2-SNAPSHOT


### PR DESCRIPTION
Snapshot modules are overridden by other snapshot modules with the same version.
For non-snapshot modules, the logic is "first come first serve" (first part of the modified if-statement).
However for snapshots this turns into "last come first serve" (second statement).

This crashed my terasology instance, where a snapshot jar was loaded instead of my workspace module. Leading to classloading issues which are not visible in the workspace where i developed against my directory module.
See [ModulePathScanner#L77](https://github.com/MovingBlocks/gestalt/blob/develop/gestalt-module/src/main/java/org/terasology/module/ModulePathScanner.java#L77) for the default order of module imports.

I think it is wrong to override a registered module if another module with exact the same name and version is found later on, independent if snapshot or not. The latestModules map will handle the latest version (including snapshots) by default.