### PR TITLE
Allow modules to load instance assets.

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/AssetType.java
@@ -335,7 +335,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
                     return Optional.ofNullable(assetClass.cast(result.get()));
                 });
             } catch (PrivilegedActionException e) {
-                logger.error("Failed to load asset '" + asset.getUrn().getInstanceUrn() + "'", e);
+                logger.error("Failed to load asset '" + asset.getUrn().getInstanceUrn() + "'", e.getCause());
             }
         }
         return Optional.ofNullable(assetClass.cast(result.get()));


### PR DESCRIPTION
This change probably fixes the instanced asset creation from issue #62 

I am not sure how to configure my terasology to use the gestalt source version.

I also didn't find a proper 5.1 branch to make this PR to as Terasology still uses 5.1.2. The commit in this PR is based on the latest 5.1.3-SNAPSHOT commit.

It would be great, if you @immortius could explain me how you test a gestalt change with Terasology without building  new version. Ideally this should also be documented so I created an issue for this: https://github.com/MovingBlocks/Terasology/issues/3027

