### PR TITLE
Fix for permission check when opening stream of AssetDataFile

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/assets/format/AssetDataFile.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/format/AssetDataFile.java
@@ -96,9 +96,11 @@ public class AssetDataFile {
      * @throws IOException If there was an error opening the file
      */
     public BufferedInputStream openStream() throws IOException {
-        Preconditions.checkState(Files.isRegularFile(path));
         try {
-            return AccessController.doPrivileged((PrivilegedExceptionAction<BufferedInputStream>) () -> new BufferedInputStream(Files.newInputStream(path)));
+            return AccessController.doPrivileged((PrivilegedExceptionAction<BufferedInputStream>) () -> {
+                Preconditions.checkState(Files.isRegularFile(path));
+                new BufferedInputStream(Files.newInputStream(path))
+            });
         } catch (PrivilegedActionException e) {
             throw new IOException("Failed to open stream for '" + path + "'", e);
         }

--- a/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAwareAssetTypeManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/assets/module/ModuleAwareAssetTypeManager.java
@@ -111,7 +111,7 @@ public class ModuleAwareAssetTypeManager implements Closeable, AssetTypeManager 
     }
 
     @Override
-    public synchronized void close() throws IOException {
+    public synchronized void close() {
         unloadEnvironment();
         assetTypeManager.clear();
         assetTypeInfo.clear();


### PR DESCRIPTION
This should allow modules to introduce Asset Formats.