### PR TITLE
Minor tweaks for Android-less workspaces, Jenkins, Artifactory... 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,17 @@ buildscript {
         google()
         jcenter()
         mavenLocal()
+        maven {
+            url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
+        // Artifactory plugin
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.7.3')
     }
 }
 
@@ -24,9 +30,8 @@ allprojects {
         jcenter()
         mavenLocal()
         maven {
-            url "http://artifactory.terasology.org/artifactory/repo"
+            url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
         }
-
     }
 }
 
@@ -37,25 +42,14 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-/*configure(subprojects.findAll { !it.name.contains("testpack") && !it.name.startsWith("module") }) {
+configure(subprojects.findAll { !it.name.contains("testpack") && !it.name.startsWith("module") && !it.name.contains("android")}) {
+    // General Java configuration
+    apply plugin: 'java'
     apply plugin: 'checkstyle'
     apply plugin: 'pmd'
     apply plugin: 'findbugs'
-    apply plugin: 'maven'
-    apply plugin: 'java-library-distribution'
-    apply plugin: 'artifactory-publish'
+    apply plugin: 'com.jfrog.artifactory'
     apply plugin: 'maven-publish'
-
-    // Primary dependencies definition
-    dependencies {
-        compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
-        compile group: 'com.google.guava', name: 'guava', version: '19.0'
-
-        // These dependencies are only needed for running tests
-        testCompile group: 'junit', name: 'junit', version: '4.12'
-        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
-        testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
-    }
 
     // Set the expected module Java level (can use a higher Java to run, but should not use features from a higher Java)
     sourceCompatibility = 1.8
@@ -63,10 +57,9 @@ task clean(type: Delete) {
 
     jar {
         manifest {
-            attributes("Implementation-Title": project.name,
-                    "Implementation-Version": version)
+            attributes("Implementation-Title": project.name, "Implementation-Version": version)
         }
-        from(['LICENSE', 'NOTICE'])
+        from(['LICENSE'])
     }
 
     task sourceJar(type: Jar) {
@@ -110,8 +103,30 @@ task clean(type: Delete) {
         }
     }
 
+    // This configures what we need to interact with the Terasology Artifactory instance. It is primarily for local test publishing
+    // Artifactory config in Jenkins can supply overrides for the following
     artifactory {
+        contextUrl = 'http://artifactory.terasology.org/artifactory'
+
+        // This is the target for publishing artifacts. Unless testing locally usually the setting in Jenkins is used
         publish {
+            repository {
+                // The repoKey can be overridden in Jenkins and via local gradle.properties if desired for testing
+                if (rootProject.hasProperty("artifactoryPublishRepo")) {
+                    repoKey = artifactoryPublishRepo
+                } else {
+                    repoKey = 'terasology-snapshot-local'
+                }
+
+                // User and pass are overridden in Jenkins. You can supply your own for manual use in a local prop file, such as gradle.properties
+                // This way we make it so you can run locally without having the user/pass set - but if the artifactoryPublish task is called it'll fail
+                if (rootProject.hasProperty("artifactoryUser") && rootProject.hasProperty("artifactoryPass")) {
+                    username = "$artifactoryUser"
+                    password = "$artifactoryPass"
+                }
+                // Note that republishing artifacts under the same name (without an incremented SNAPSHOT for instance) may fail with "Forbidden"
+            }
+
             defaults {
                 publications('mavenJava')
             }
@@ -148,6 +163,4 @@ task clean(type: Delete) {
     javadoc {
         failOnError = false
     }
-}*/
-
-
+}

--- a/gestalt-android-testbed/build.gradle
+++ b/gestalt-android-testbed/build.gradle
@@ -53,9 +53,21 @@ buildscript {
         mavenLocal()
         google()
         jcenter()
+        maven {
+            url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+        }
     }
     dependencies {
         classpath 'org.reflections:reflections:0.9.12-SNAPSHOT'
+    }
+}
+
+repositories {
+    google()
+    jcenter()
+    mavenLocal()
+    maven {
+        url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
     }
 }
 

--- a/gestalt-android/build.gradle
+++ b/gestalt-android/build.gradle
@@ -40,6 +40,12 @@ android {
 
 }
 
+repositories {
+    maven {
+        url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+    }
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api project(':gestalt-module')
@@ -50,4 +56,62 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+}
+
+
+// Artifactory publishing details
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.7.3')
+    }
+}
+
+apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'maven-publish'
+
+// A configuration for publishing artifacts
+configurations {
+    published
+}
+
+publishing {
+    publications {
+        aar(MavenPublication) {
+            artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+        }
+    }
+}
+
+// This configures what we need to interact with the Terasology Artifactory instance. It is primarily for local test publishing
+// Artifactory config in Jenkins can supply overrides for the following
+artifactory {
+    contextUrl = 'http://artifactory.terasology.org/artifactory'
+
+    // This is the target for publishing artifacts. Unless testing locally usually the setting in Jenkins is used
+    publish {
+        repository {
+            // The repoKey can be overridden in Jenkins and via local gradle.properties if desired for testing
+            if (rootProject.hasProperty("artifactoryPublishRepo")) {
+                repoKey = artifactoryPublishRepo
+            } else {
+                repoKey = 'terasology-snapshot-local'
+            }
+
+            // User and pass are overridden in Jenkins. You can supply your own for manual use in a local prop file, such as gradle.properties
+            // This way we make it so you can run locally without having the user/pass set - but if the artifactoryPublish task is called it'll fail
+            if (rootProject.hasProperty("artifactoryUser") && rootProject.hasProperty("artifactoryPass")) {
+                username = "$artifactoryUser"
+                password = "$artifactoryPass"
+            }
+            // Note that republishing artifacts under the same name (without an incremented SNAPSHOT for instance) may fail with "Forbidden"
+        }
+
+        defaults {
+            publications('aar')
+            publishArtifacts = true
+        }
+    }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/assets/module/autoreload/ModuleEnvironmentWatcherTest.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/assets/module/autoreload/ModuleEnvironmentWatcherTest.java
@@ -108,7 +108,17 @@ public class ModuleEnvironmentWatcherTest {
         }
         changed = watcher.checkForChanges();
         assertTrue(changed.containsEntry(assetType, new ResourceUrn(module.getId(), new Name("test.txt"))));
-        FilesUtil.recursiveDelete(tempDirectory);
+        try {
+            FilesUtil.recursiveDelete(tempDirectory);
+        } catch (IOException e) {
+            // Observed on Windows 10 to fail - timing issue? Try again after a brief moment!
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException ignore) {
+
+            }
+            FilesUtil.recursiveDelete(tempDirectory);
+        }
         watcher.checkForChanges();
 
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,8 @@
 rootProject.name = 'gestalt'
-include 'gestalt-util', 'testpack:testpack-api', 'gestalt-module', 'testpack:moduleA', 'testpack:moduleB', 'testpack:moduleC', 'testpack:moduleD', 'gestalt-asset-core', 'gestalt-entity-system', 'gestalt-es-perf', 'gestalt-bifrost', 'gestalt-benchmark', 'gestalt-android', 'gestalt-android-testbed'
+include 'gestalt-util', 'testpack:testpack-api', 'gestalt-module', 'testpack:moduleA', 'testpack:moduleB', 'testpack:moduleC', 'testpack:moduleD', 'gestalt-asset-core', 'gestalt-entity-system', 'gestalt-es-perf', 'gestalt-bifrost', 'gestalt-benchmark'
+
+if (new File("local.properties").exists()) {
+    include 'gestalt-android', 'gestalt-android-testbed'
+} else {
+    println "No local.properties file found, bypassing Android elements"
+}

--- a/testpack/moduleA/build.gradle
+++ b/testpack/moduleA/build.gradle
@@ -36,6 +36,9 @@ buildscript {
         mavenLocal()
         google()
         jcenter()
+        maven {
+            url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+        }
     }
     dependencies {
         classpath 'org.reflections:reflections:0.9.12-SNAPSHOT'


### PR DESCRIPTION
Plus a weird unit test quirk on Win10.

Goal of this was to aid in https://github.com/MovingBlocks/DestinationSol/pull/418 to let us build & publish Gestalt at its v7 SNAPSHOT level so it could be tested via binaries for DS. Needed to readd some Artifactory-related pieces and what not. I also made it so you could work with Gestalt without necessarily having a full Android setup, which would allow easier local dev + let us build in Jenkins right now _without_ the Android piece (a bit tricky to set up in CI - but it is coming!)

Separately I also built and manually published the reflections snapshot dependency so it can just be pulled out of Artifactory rather than be built locally first.

This isn't clean quite yet - pretty much threw stuff at the wall to see what would stick and yield published binaries in Artifactory from a local build, with credentials added to `gradle.properties`. Need to go back and take back out the cruft that isn't needed. Code analytics are live again but out of date and really need an overhaul, the launcher has gone to SpotBugs instead of FindBugs for instance and there's a new set of analytics plugins in Jenkins to play with.

I also managed to put it in not quite the right place as it went to http://artifactory.terasology.org/artifactory/webapp/#/artifacts/browse/tree/General/terasology-snapshot-local/gestalt rather than libs-snapshot. More stuff to clean up and fix before this is ready :-)

Builds on https://github.com/MovingBlocks/gestalt/pull/68 naturally, with thanks to @immortius for getting this rolling and to @BenjaminAmos for putting it to work on DS!

Edit: I also ran all the unit tests (as perhaps indicated by including a workaround for one on Windows) _including_ the full Android setup with a simulator, all appeared well! Finally got Android Studio set up