### PR TITLE
removed upper and lower for name

### DIFF
--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -51,7 +51,7 @@ public final class Name implements Comparable<Name> {
     /**
      * @return The original name when string is passed into name
      */
-    public String originalName() {
+    public String displayName() {
         return originalName;
     }
 

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -39,24 +39,24 @@ public final class Name implements Comparable<Name> {
      */
     public static final Name EMPTY = new Name("");
 
-    private final String originalName;
+    private final String normalizedName;
 
     public Name(String name) {
         Preconditions.checkNotNull(name);
-        this.originalName = name;
+        this.normalizedName = name.toLowerCase(Locale.ENGLISH);
     }
 
     /**
      * @return Whether this name is empty (equivalent to an empty string)
      */
     public boolean isEmpty() {
-        return originalName.isEmpty();
+        return normalizedName.isEmpty();
     }
 
 
     @Override
     public int compareTo(Name o) {
-        return originalName.compareTo(o.originalName);
+        return normalizedName.compareTo(o.normalizedName);
     }
 
     @Override
@@ -66,18 +66,18 @@ public final class Name implements Comparable<Name> {
         }
         if (obj instanceof Name) {
             Name other = (Name) obj;
-            return originalName.equals(other.originalName);
+            return normalizedName.equals(other.normalizedName);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return originalName.hashCode();
+        return normalizedName.hashCode();
     }
 
     @Override
     public String toString() {
-        return originalName;
+        return normalizedName;
     }
 }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A name is a normalised string used as an identifier. Primarily this means it is case insensitive.
+ * A name is a normalisedName string used as an identifier. Primarily this means it is case insensitive.
  * <p>
  * The original case-sensitive name is retained and available for display purposes, since it may use camel casing for readability.
  * </p><p>
@@ -39,20 +39,20 @@ public final class Name implements Comparable<Name> {
      */
     public static final Name EMPTY = new Name("");
 
-    private final String normalised;
+    private final String normalisedName;
     private final String originalName;
 
     public Name(String name) {
         Preconditions.checkNotNull(name);
         this.originalName = name;
-        this.normalised = name.toLowerCase(Locale.ENGLISH);
+        this.normalisedName = name.toLowerCase(Locale.ENGLISH);
     }
 
     /**
      * @return Whether this name is empty (equivalent to an empty string)
      */
     public boolean isEmpty() {
-        return normalised.isEmpty();
+        return normalisedName.isEmpty();
     }
 
     /**
@@ -63,7 +63,7 @@ public final class Name implements Comparable<Name> {
      */
     @Deprecated
     public String toLowerCase() {
-        return normalised;
+        return normalisedName;
     }
 
     /**
@@ -79,16 +79,16 @@ public final class Name implements Comparable<Name> {
 
     @Override
     public int compareTo(Name o) {
-        return normalised.compareTo(o.normalised);
+        return normalisedName.compareTo(o.normalisedName);
     }
 
     /**
-     * normalises the string and compares it to the normalised version used for @{@linkplain Name}
+     * normalises the string and compares it to the normalisedName version used for @{@linkplain Name}
      * @param other string to compare against
-     * @return string comparision with normalised version 0 if match and unmatched with anything else
+     * @return string comparision with normalisedName version 0 if match and unmatched with anything else
      */
     public int compareTo(String other) {
-        return normalised.compareTo(other.toLowerCase(Locale.ENGLISH));
+        return normalisedName.compareTo(other.toLowerCase(Locale.ENGLISH));
     }
 
 
@@ -99,14 +99,14 @@ public final class Name implements Comparable<Name> {
         }
         if (obj instanceof Name) {
             Name other = (Name) obj;
-            return normalised.equals(other.normalised);
+            return normalisedName.equals(other.normalisedName);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return normalised.hashCode();
+        return normalisedName.hashCode();
     }
 
     /**

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -75,8 +75,11 @@ public final class Name implements Comparable<Name> {
 
     /**
      * @return The Name in uppercase consistent with Name equality (so two names that are equal will have the same uppercase)
-     * @deprecated
+     * @deprecated This is scheduled for removal in upcoming versions. 
+     *             Use {@code toString} or {@code displayName} instead.
+     *             Note that a Name should not be transformed to a String for further processing.
      */
+    @Deprecated
     public String toUpperCase() {
         return originalName.toUpperCase(Locale.ENGLISH);
     }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -110,7 +110,7 @@ public final class Name implements Comparable<Name> {
     }
 
     /**
-     * @return The Name as string consistent with Name equality (so two names that are equal will have the same {@code toString})
+     * @return The Name as string for display purposes
      */
     @Override
     public String toString() {

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -40,10 +40,19 @@ public final class Name implements Comparable<Name> {
     public static final Name EMPTY = new Name("");
 
     private final String normalizedName;
+    private final String originalName;
 
     public Name(String name) {
         Preconditions.checkNotNull(name);
+        this.originalName = name;
         this.normalizedName = name.toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * @return The original name when string is passed into name
+     */
+    public String originalName() {
+        return originalName;
     }
 
     /**

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -40,38 +40,23 @@ public final class Name implements Comparable<Name> {
     public static final Name EMPTY = new Name("");
 
     private final String originalName;
-    private final String normalisedName;
 
     public Name(String name) {
         Preconditions.checkNotNull(name);
         this.originalName = name;
-        this.normalisedName = name.toLowerCase(Locale.ENGLISH);
     }
 
     /**
      * @return Whether this name is empty (equivalent to an empty string)
      */
     public boolean isEmpty() {
-        return normalisedName.isEmpty();
+        return originalName.isEmpty();
     }
 
-    /**
-     * @return The Name in lowercase consistent with Name equality (so two names that are equal will have the same lowercase)
-     */
-    public String toLowerCase() {
-        return normalisedName;
-    }
-
-    /**
-     * @return The Name in uppercase consistent with Name equality (so two names that are equal will have the same uppercase)
-     */
-    public String toUpperCase() {
-        return originalName.toUpperCase(Locale.ENGLISH);
-    }
 
     @Override
     public int compareTo(Name o) {
-        return normalisedName.compareTo(o.normalisedName);
+        return originalName.compareTo(o.originalName);
     }
 
     @Override
@@ -81,20 +66,18 @@ public final class Name implements Comparable<Name> {
         }
         if (obj instanceof Name) {
             Name other = (Name) obj;
-            return normalisedName.equals(other.normalisedName);
+            return originalName.equals(other.originalName);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return normalisedName.hashCode();
+        return originalName.hashCode();
     }
 
     @Override
     public String toString() {
         return originalName;
     }
-
-
 }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -64,8 +64,11 @@ public final class Name implements Comparable<Name> {
 
     /**
      * @return The Name in lowercase consistent with Name equality (so two names that are equal will have the same lowercase)
-     * @deprecated
+     * @deprecated This is scheduled for removal in upcoming versions. 
+     *             Use {@code toString} or {@code displayName} instead.
+     *             Note that a Name should not be transformed to a String for further processing.
      */
+    @Deprecated
     public String toLowerCase() {
         return normalizedName;
     }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -103,6 +103,9 @@ public final class Name implements Comparable<Name> {
         return normalizedName.hashCode();
     }
 
+    /**
+      * @return The Name as string consistent with Name equality (so two names that are equal will have the same {@code toString})
+      */
     @Override
     public String toString() {
         return normalizedName;

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -49,7 +49,7 @@ public final class Name implements Comparable<Name> {
     }
 
     /**
-     * @return The original name when string is passed into name
+     * @return The original <b>case-sensitive</b>  name when string is passed into name
      */
     public String displayName() {
         return originalName;
@@ -62,6 +62,21 @@ public final class Name implements Comparable<Name> {
         return normalizedName.isEmpty();
     }
 
+    /**
+     * @return The Name in lowercase consistent with Name equality (so two names that are equal will have the same lowercase)
+     * @deprecated
+     */
+    public String toLowerCase() {
+        return normalizedName;
+    }
+
+    /**
+     * @return The Name in uppercase consistent with Name equality (so two names that are equal will have the same uppercase)
+     * @deprecated
+     */
+    public String toUpperCase() {
+        return originalName.toUpperCase(Locale.ENGLISH);
+    }
 
     @Override
     public int compareTo(Name o) {

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -91,7 +91,6 @@ public final class Name implements Comparable<Name> {
         return normalisedName.compareTo(other.toLowerCase(Locale.ENGLISH));
     }
 
-
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -116,6 +115,4 @@ public final class Name implements Comparable<Name> {
     public String toString() {
         return originalName;
     }
-
-    
 }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * A name is a normalisedName string used as an identifier. Primarily this means it is case insensitive.
+ * A name is a normalised string used as an identifier. Primarily this means it is case insensitive.
  * <p>
  * The original case-sensitive name is retained and available for display purposes, since it may use camel casing for readability.
  * </p><p>
@@ -39,8 +39,8 @@ public final class Name implements Comparable<Name> {
      */
     public static final Name EMPTY = new Name("");
 
-    private final String normalisedName;
     private final String originalName;
+    private final String normalisedName;
 
     public Name(String name) {
         Preconditions.checkNotNull(name);
@@ -116,4 +116,6 @@ public final class Name implements Comparable<Name> {
     public String toString() {
         return originalName;
     }
+
+    
 }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Name.java
@@ -39,45 +39,38 @@ public final class Name implements Comparable<Name> {
      */
     public static final Name EMPTY = new Name("");
 
-    private final String normalizedName;
+    private final String normalised;
     private final String originalName;
 
     public Name(String name) {
         Preconditions.checkNotNull(name);
         this.originalName = name;
-        this.normalizedName = name.toLowerCase(Locale.ENGLISH);
-    }
-
-    /**
-     * @return The original <b>case-sensitive</b>  name when string is passed into name
-     */
-    public String displayName() {
-        return originalName;
+        this.normalised = name.toLowerCase(Locale.ENGLISH);
     }
 
     /**
      * @return Whether this name is empty (equivalent to an empty string)
      */
     public boolean isEmpty() {
-        return normalizedName.isEmpty();
+        return normalised.isEmpty();
     }
 
     /**
      * @return The Name in lowercase consistent with Name equality (so two names that are equal will have the same lowercase)
-     * @deprecated This is scheduled for removal in upcoming versions. 
-     *             Use {@code toString} or {@code displayName} instead.
-     *             Note that a Name should not be transformed to a String for further processing.
+     * @deprecated This is scheduled for removal in upcoming versions.
+     * Use {@code toString} or {@code displayName} instead.
+     * Note that a Name should not be transformed to a String for further processing.
      */
     @Deprecated
     public String toLowerCase() {
-        return normalizedName;
+        return normalised;
     }
 
     /**
      * @return The Name in uppercase consistent with Name equality (so two names that are equal will have the same uppercase)
-     * @deprecated This is scheduled for removal in upcoming versions. 
-     *             Use {@code toString} or {@code displayName} instead.
-     *             Note that a Name should not be transformed to a String for further processing.
+     * @deprecated This is scheduled for removal in upcoming versions.
+     * Use {@code toString} or {@code displayName} instead.
+     * Note that a Name should not be transformed to a String for further processing.
      */
     @Deprecated
     public String toUpperCase() {
@@ -86,8 +79,18 @@ public final class Name implements Comparable<Name> {
 
     @Override
     public int compareTo(Name o) {
-        return normalizedName.compareTo(o.normalizedName);
+        return normalised.compareTo(o.normalised);
     }
+
+    /**
+     * normalises the string and compares it to the normalised version used for @{@linkplain Name}
+     * @param other string to compare against
+     * @return string comparision with normalised version 0 if match and unmatched with anything else
+     */
+    public int compareTo(String other) {
+        return normalised.compareTo(other.toLowerCase(Locale.ENGLISH));
+    }
+
 
     @Override
     public boolean equals(Object obj) {
@@ -96,21 +99,21 @@ public final class Name implements Comparable<Name> {
         }
         if (obj instanceof Name) {
             Name other = (Name) obj;
-            return normalizedName.equals(other.normalizedName);
+            return normalised.equals(other.normalised);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return normalizedName.hashCode();
+        return normalised.hashCode();
     }
 
     /**
-      * @return The Name as string consistent with Name equality (so two names that are equal will have the same {@code toString})
-      */
+     * @return The Name as string consistent with Name equality (so two names that are equal will have the same {@code toString})
+     */
     @Override
     public String toString() {
-        return normalizedName;
+        return originalName;
     }
 }


### PR DESCRIPTION
This issue for terasology shows kind of a key problem with transforming the name of the asset in gestalt. https://github.com/MovingBlocks/Terasology/issues/3887 I think we should avoid transforming the name at all and just use the name that was provided by the asset. Any kind of additional transformation on the type seems like a good way to introducing bugs. for one case it might be uppercase but another case it could be lower. When systems intersect is where we will see kind of a mix of the two and working out if its one or the other seems like a major problem. 