### PR TITLE
Bumped gradle version to 5.6.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ configure(subprojects.findAll { !it.name.contains("testpack") && !it.name.starts
 
 // gradle wrapper version
 wrapper {
-    gradleVersion '1.10'
+    gradleVersion '5.6.4'
 }
 
 ext {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip


### PR DESCRIPTION
Can't bump to 6.X since 'findbugs' is deprecated after 5.6.4