### PR TITLE
feat: Improve Semver support

### DIFF
--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -24,6 +24,12 @@
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 
+repositories {
+    maven {
+        url = 'https://heisluft.tk/maven/'
+    }
+}
+
 // Primary dependencies definition
 dependencies {
     api 'org.terasology:reflections:0.9.12-MB'
@@ -34,6 +40,7 @@ dependencies {
     implementation 'org.apache.commons:commons-vfs2:2.2'
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
+    implementation "com.github.zafarkhaja:java-semver:0.10.0"
 
     testImplementation project(":testpack:testpack-api")
     testImplementation "junit:junit:$junit_version"


### PR DESCRIPTION
This is an attempt to improve the compatibility with Semver v2 as
defined by https://semver.org/ by introducing [**jsemver**](https://github.com/AntiLaby/jsemver) as internal
representation for the Version class.

Note that these changes lead to slightly different behavior in the
increment methods. Previously, the respective version level would be
increased while setting all less important numbers (to the right) to
zero. For instance

```java
new Version("1.2.0-SNAPSHOT").getNextMinorVersion()   // 1.3.0
```

With basing the internal representation on jsemver this changed to

```java
new Version("1.2.0-SNAPSHO").getNextMinorVersion()    // 1.2.0
```

Similar different behavior can be observed for the other parts.

With jsemver as internal representation we could easily support more of
Semver specification in _gestalt_ by exposing both the full _prerelease_
information and the _build metadata_.
I'd also like to offer methods for version increments which will
directly set the prerelease information, like

```java
version.getNextMinorVersion("SNAPSHOT")
```

This would be helpful for implementing CLI tooling in Terasology to
easily prepare a specific release and switch to the next snapshot
version.

Please feel free to share suggestions or opinions on this. I was also
considering to implement the Semver specification from scratch or
whether we should fork the whole project...
