### PR TITLE
fix: adjust URL for a 3rd party artifact repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
         mavenLocal()
         maven {
-            url 'https://heisluft.tk/maven'
+            url 'https://heisluft.de/maven'
         }
         maven {
             url "http://artifactory.terasology.org/artifactory/libs-release-local"
@@ -50,7 +50,7 @@ allprojects {
             url "http://artifactory.terasology.org/artifactory/libs-release-local"
         }
         maven {
-            url 'https://heisluft.tk/maven'
+            url 'https://heisluft.de/maven'
         }
     }
 }

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'maven-publish'
 
 repositories {
     maven {
-        url = 'https://heisluft.tk/maven/'
+        url = 'https://heisluft.de/maven/'
     }
 }
 


### PR DESCRIPTION
The old `.tk` address failed occasionally, looks like the author is using a `.de` instead now.

Still makes me a bit nervous to depend on such an esoteric 3rd party repo, releases prior to `.0.10.0` were also in Maven Central. If the newest doesn't end up in there soon ™️ maybe we should consider publishing a copy to our Artifactory, just in case.

Only latest Gestalt seems to use it, so no corresponding fix to the `5.1.x` line. Only known consumer is latest DestSol which was fixed via https://github.com/MovingBlocks/DestinationSol/pull/555