### PR TITLE
Integrate gestalt-di to gestalt-module

### DIFF
--- a/gestalt-asset-core/build.gradle
+++ b/gestalt-asset-core/build.gradle
@@ -29,17 +29,31 @@ dependencies {
     implementation project(":gestalt-util")
     implementation project(":gestalt-module")
     implementation project(":gestalt-inject")
+    annotationProcessor project(":gestalt-inject-java")
+    
 
     implementation "com.google.guava:guava:$guava_version"
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
     implementation "net.jcip:jcip-annotations:$jcip_annotation_version"
 
+    testAnnotationProcessor project(":gestalt-inject-java")
     testImplementation "junit:junit:$junit_version"
     testImplementation "ch.qos.logback:logback-classic:$logback_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"
 
 }
+
+
+compileJava {
+    inputs.files sourceSets.main.resources.srcDirs
+    options.compilerArgs = ["-Aresource=${sourceSets.main.resources.srcDirs.join(File.pathSeparator)}"]
+}
+compileTestJava {
+    inputs.files sourceSets.test.resources.srcDirs
+    options.compilerArgs = ["-Aresource=${sourceSets.test.resources.srcDirs.join(File.pathSeparator)}"]
+}
+
 
 description = 'Provides support for assets - binary resources that can be loaded from modules or procedurally generated at runtime.'
 

--- a/gestalt-asset-core/build.gradle
+++ b/gestalt-asset-core/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation project(":gestalt-module")
     implementation project(":gestalt-inject")
 
-    implementation "com.google.guava:guava:$guava_version" // TODO remove it.
+    implementation "com.google.guava:guava:$guava_version"
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
     implementation "net.jcip:jcip-annotations:$jcip_annotation_version"

--- a/gestalt-asset-core/build.gradle
+++ b/gestalt-asset-core/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation project(":gestalt-module")
     implementation project(":gestalt-inject")
 
+    implementation "com.google.guava:guava:$guava_version" // TODO remove it.
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
     implementation "net.jcip:jcip-annotations:$jcip_annotation_version"

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/management/MapAssetTypeManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/management/MapAssetTypeManager.java
@@ -17,17 +17,13 @@
 package org.terasology.gestalt.assets.management;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Multimaps;
-
 import net.jcip.annotations.ThreadSafe;
-
-import org.reflections.ReflectionUtils;
 import org.terasology.gestalt.assets.Asset;
 import org.terasology.gestalt.assets.AssetData;
 import org.terasology.gestalt.assets.AssetFactory;
@@ -35,7 +31,6 @@ import org.terasology.gestalt.assets.AssetType;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -109,11 +104,11 @@ public final class MapAssetTypeManager implements AssetTypeManager {
         Preconditions.checkState(assetTypes.get(assetType.getAssetClass()) == null, "Asset type already registered for - " + assetType.getAssetClass().getSimpleName());
 
         assetTypes.put(assetType.getAssetClass(), assetType);
-        for (Class<?> parentType : ReflectionUtils.getAllSuperTypes(assetType.getAssetClass(), (Predicate<Class<?>>) input -> Asset.class.isAssignableFrom(input) && input != Asset.class)) {
-            subtypes.put((Class<? extends Asset>) parentType, assetType.getAssetClass());
-            (subtypes.get((Class<? extends Asset>) parentType)).sort(Comparator.comparing(Class::getSimpleName));
-
-        }
+//        for (Class<?> parentType : ReflectionUtils.getAllSuperTypes(assetType.getAssetClass(), (Predicate<Class<?>>) input -> Asset.class.isAssignableFrom(input) && input != Asset.class)) {
+//            subtypes.put((Class<? extends Asset>) parentType, assetType.getAssetClass());
+//            (subtypes.get((Class<? extends Asset>) parentType)).sort(Comparator.comparing(Class::getSimpleName));
+//
+//        }
     }
 
     /**
@@ -128,9 +123,9 @@ public final class MapAssetTypeManager implements AssetTypeManager {
         AssetType<?, ?> assetType = assetTypes.remove(type);
         if (assetType != null) {
             assetType.close();
-            for (Class<?> parentType : ReflectionUtils.getAllSuperTypes(type, (Predicate<Class<?>>) input -> Asset.class.isAssignableFrom(input) && input != Asset.class)) {
-                subtypes.remove(parentType, type);
-            }
+//            for (Class<?> parentType : ReflectionUtils.getAllSuperTypes(type, (Predicate<Class<?>>) input -> Asset.class.isAssignableFrom(input) && input != Asset.class)) {
+//                subtypes.remove(parentType, type);
+//            }
         }
         return assetType;
     }

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/management/MapAssetTypeManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/management/MapAssetTypeManager.java
@@ -48,7 +48,7 @@ public final class MapAssetTypeManager implements AssetTypeManager {
     private final ListMultimap<Class<? extends Asset>, Class<? extends Asset>> subtypes =
             Multimaps.synchronizedListMultimap(ArrayListMultimap.<Class<? extends Asset>, Class<? extends Asset>>create());
 
-    private static Iterable<Class<?>> getAllSuperTypesBetween(Class<?> upperBound, Class<?> lowerBound) {
+    private static Iterable<Class<?>> getAllSuperClasses(Class<?> from, Class<?> to) {
         Preconditions.checkArgument(lowerBound.isAssignableFrom(upperBound), "%s should be subtype of %s", upperBound, lowerBound);
         List<Class<?>> subtypes = Lists.newArrayList();
         Class<?> current = upperBound;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetDataProducer.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetDataProducer.java
@@ -17,6 +17,7 @@
 package org.terasology.gestalt.assets.module.annotations;
 
 import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.Index;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManagerImpl;
 
 import java.lang.annotation.ElementType;
@@ -40,5 +41,6 @@ import java.lang.annotation.Target;
 @API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterAssetDataProducer {
 }

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetDeltaFileFormat.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetDeltaFileFormat.java
@@ -17,6 +17,7 @@
 package org.terasology.gestalt.assets.module.annotations;
 
 import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.Index;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManagerImpl;
 
 import java.lang.annotation.ElementType;
@@ -41,5 +42,6 @@ import java.lang.annotation.Target;
 @API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterAssetDeltaFileFormat {
 }

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetFileFormat.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetFileFormat.java
@@ -17,6 +17,7 @@
 package org.terasology.gestalt.assets.module.annotations;
 
 import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.Index;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManagerImpl;
 
 import java.lang.annotation.ElementType;
@@ -36,5 +37,6 @@ import java.lang.annotation.Target;
 @API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterAssetFileFormat {
 }

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetSupplementalFileFormat.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetSupplementalFileFormat.java
@@ -17,7 +17,9 @@
 package org.terasology.gestalt.assets.module.annotations;
 
 import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.Index;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManagerImpl;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -41,5 +43,6 @@ import java.lang.annotation.Target;
 @API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterAssetSupplementalFileFormat {
 }

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/module/annotations/RegisterAssetType.java
@@ -17,6 +17,7 @@
 package org.terasology.gestalt.assets.module.annotations;
 
 import org.terasology.context.annotation.API;
+import org.terasology.context.annotation.Index;
 import org.terasology.gestalt.assets.AssetFactory;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManagerImpl;
 
@@ -41,6 +42,7 @@ import java.lang.annotation.Target;
 @API
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface RegisterAssetType {
     /**
      * @return The subdirectory where assets of this type will be discovered. Can be omitted for asset types that are not loaded from files.

--- a/gestalt-asset-core/src/test/java/org/terasology/gestalt/assets/module/TestModulesUtil.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/gestalt/assets/module/TestModulesUtil.java
@@ -17,7 +17,7 @@
 package org.terasology.gestalt.assets.module;
 
 import com.google.common.collect.Lists;
-
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.ModuleFactory;
 import org.terasology.gestalt.module.sandbox.PermitAllPermissionProviderFactory;
@@ -55,11 +55,11 @@ public final class TestModulesUtil {
 
     public static ModuleEnvironment createFullEnvironment() {
         ModuleFactory factory = new ModuleFactory();
-        return new ModuleEnvironment(VIRTUAL_MODULES.stream().map(x -> factory.createPackageModule(VIRTUAL_MODULE_ROOT + "." + x)).collect(Collectors.toList()), new PermitAllPermissionProviderFactory());
+        return new ModuleEnvironment(new DefaultBeanContext(), VIRTUAL_MODULES.stream().map(x -> factory.createPackageModule(VIRTUAL_MODULE_ROOT + "." + x)).collect(Collectors.toList()), new PermitAllPermissionProviderFactory());
     }
 
     public static ModuleEnvironment createEmptyEnvironment() {
-        return new ModuleEnvironment(Collections.emptyList(), new PermitAllPermissionProviderFactory());
+        return new ModuleEnvironment(new DefaultBeanContext(), Collections.emptyList(), new PermitAllPermissionProviderFactory());
     }
 
     public static ModuleEnvironment createEnvironment() {
@@ -72,11 +72,11 @@ public final class TestModulesUtil {
 
     public static ModuleEnvironment createEnvironment(List<String> modules) {
         ModuleFactory factory = new ModuleFactory();
-        return new ModuleEnvironment(modules.stream().map(x -> factory.createPackageModule(VIRTUAL_MODULE_ROOT + "." + x)).collect(Collectors.toList()), new PermitAllPermissionProviderFactory());
+        return new ModuleEnvironment(new DefaultBeanContext(), modules.stream().map(x -> factory.createPackageModule(VIRTUAL_MODULE_ROOT + "." + x)).collect(Collectors.toList()), new PermitAllPermissionProviderFactory());
     }
 
     public static ModuleEnvironment createEnvironment(Name... modules) {
         ModuleFactory factory = new ModuleFactory();
-        return new ModuleEnvironment(Arrays.stream(modules).map(x -> factory.createPackageModule(VIRTUAL_MODULE_ROOT + "." + x)).collect(Collectors.toList()), new PermitAllPermissionProviderFactory());
+        return new ModuleEnvironment(new DefaultBeanContext(), Arrays.stream(modules).map(x -> factory.createPackageModule(VIRTUAL_MODULE_ROOT + "." + x)).collect(Collectors.toList()), new PermitAllPermissionProviderFactory());
     }
 }

--- a/gestalt-asset-core/src/test/java/org/terasology/gestalt/assets/module/autoreload/ModuleEnvironmentWatcherTest.java
+++ b/gestalt-asset-core/src/test/java/org/terasology/gestalt/assets/module/autoreload/ModuleEnvironmentWatcherTest.java
@@ -17,13 +17,13 @@
 package org.terasology.gestalt.assets.module.autoreload;
 
 import com.google.common.collect.SetMultimap;
-
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.assets.AssetType;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.format.producer.FileChangeSubscriber;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.ModuleFactory;
@@ -33,6 +33,9 @@ import org.terasology.gestalt.module.sandbox.PermitAllPermissionProviderFactory;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.Version;
 import org.terasology.gestalt.util.io.FilesUtil;
+import virtualModules.test.stubs.text.Text;
+import virtualModules.test.stubs.text.TextData;
+import virtualModules.test.stubs.text.TextFactory;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -40,10 +43,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Optional;
-
-import virtualModules.test.stubs.text.Text;
-import virtualModules.test.stubs.text.TextData;
-import virtualModules.test.stubs.text.TextFactory;
 
 import static org.junit.Assert.assertTrue;
 
@@ -56,7 +55,7 @@ public class ModuleEnvironmentWatcherTest {
         Path tempDirectory = Files.createTempDirectory("gestalt-test");
         ModuleMetadata metadata = new ModuleMetadata(new Name("test"), Version.DEFAULT);
         Module module = new ModuleFactory().createDirectoryModule(metadata, tempDirectory.toFile());
-        ModuleEnvironment environment = new ModuleEnvironment(Collections.singletonList(module), new PermitAllPermissionProviderFactory());
+        ModuleEnvironment environment = new ModuleEnvironment(new DefaultBeanContext(), Collections.singletonList(module), new PermitAllPermissionProviderFactory());
         ModuleEnvironmentWatcher watcher = new ModuleEnvironmentWatcher(environment);
         FileChangeSubscriber subscriber = new FileChangeSubscriber() {
             @Override

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/BeanEnvironment.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/BeanEnvironment.java
@@ -22,58 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 /**
  * A internal environment that has internal information that is shared between multiple context.
  */
 public class BeanEnvironment {
-
-    private static class ClassRef<T> {
-        public final Class<T> target;
-        public final String prefix;
-        public final BeanDefinition<T> definition;
-
-        public ClassRef(BeanDefinition<T> definition) {
-            this.target = definition.targetClass();
-            this.prefix = target.getName();
-            this.definition = definition;
-        }
-
-        public ClassRef(Class<T> target) {
-            this.target = target;
-            this.prefix = target.getName();
-            this.definition = null;
-        }
-
-        public ClassRef(String prefix) {
-            target = null;
-            this.definition = null;
-            this.prefix = prefix;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            ClassRef<?> that = (ClassRef<?>) o;
-            return Objects.equals(target, that.target);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(target);
-        }
-    }
-
-    private static class ClassLookup {
-        private ClassRef<?>[] namespaceIndex;
-        private Map<Class<?>, ClassRef<?>[]> interfaceIndex;
-        private Map<Class<?>, BeanDefinition<?>> definitions;
-    }
 
     public static final ClassLoader BaseClassLoader = BeanEnvironment.class.getClassLoader();
     private final Map<ClassLoader, ClassLookup> beanLookup = new HashMap<>();
@@ -178,7 +132,7 @@ public class BeanEnvironment {
     /**
      * Filter bean Definitions by class that implements a targetInterface with a given classloader that is already loaded into the enviroment
      *
-     * @param loader target class loader
+     * @param loader          target class loader
      * @param targetInterface target inerface
      * @param <T>
      * @return A collection of BeanDefinition
@@ -200,6 +154,35 @@ public class BeanEnvironment {
      */
     public <T> Iterable<BeanDefinition<? extends T>> byInterface(Class<T> targetInterface) {
         return Iterables.concat(beanLookup.keySet().stream().map(k -> byInterface(k, targetInterface)).collect(Collectors.toList()));
+    }
+
+    /**
+     * Filter bean Definitions by class that implements a targetAnnotation with a given classloader that is already loaded into the enviroment
+     *
+     * @param loader           target class loader
+     * @param targetAnnotation target inerface
+     * @return A collection of BeanDefinition
+     */
+    public Iterable<BeanDefinition<?>> byAnnotation(ClassLoader loader, Class<?> targetAnnotation) {
+        final ClassLookup lookup = beanLookup.get(loader);
+        if (!lookup.annotationIndex.containsKey(targetAnnotation)) {
+            return Collections::emptyIterator;
+        }
+        return Arrays.stream(lookup.annotationIndex.get(targetAnnotation))
+                .map(k -> (BeanDefinition<?>) k.definition)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Filter {@link BeanDefinition} by class that implements a targetAnnotation
+     *
+     * @param targetAnnotation the target interface
+     * @return a collection of BeanDefinition
+     */
+    public Iterable<BeanDefinition<?>> byAnnotation(Class<?> targetAnnotation) {
+        return Iterables.concat(beanLookup.keySet().stream()
+                .map(k -> byAnnotation(k, targetAnnotation))
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -281,5 +264,49 @@ public class BeanEnvironment {
     public <T> BeanDefinition<?> getDefinition(Class<T> beanType) {
         final ClassLookup lookup = beanLookup.get(beanType.getClassLoader());
         return lookup.definitions.get(beanType);
+    }
+
+    private static class ClassRef<T> {
+        public final Class<T> target;
+        public final String prefix;
+        public final BeanDefinition<T> definition;
+
+        public ClassRef(BeanDefinition<T> definition) {
+            this.target = definition.targetClass();
+            this.prefix = target.getName();
+            this.definition = definition;
+        }
+
+        public ClassRef(Class<T> target) {
+            this.target = target;
+            this.prefix = target.getName();
+            this.definition = null;
+        }
+
+        public ClassRef(String prefix) {
+            target = null;
+            this.definition = null;
+            this.prefix = prefix;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ClassRef<?> that = (ClassRef<?>) o;
+            return Objects.equals(target, that.target);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(target);
+        }
+    }
+
+    private static class ClassLookup {
+        private ClassRef<?>[] namespaceIndex;
+        private Map<Class<?>, ClassRef<?>[]> interfaceIndex;
+        private Map<Class<?>, BeanDefinition<?>> definitions;
+        private Map<Class<?>, ClassRef<?>[]> annotationIndex;
     }
 }

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/BeanEnvironment.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/BeanEnvironment.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.gestalt.di;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
@@ -224,7 +223,6 @@ public class BeanEnvironment {
     }
 
     public Iterable<BeanDefinition<?>> byPrefix(ClassLoader loader, String prefix) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(prefix));
         final ClassLookup lookup = beanLookup.get(loader);
 
         Optional<Range<Integer>> range = findPrefixBounds(prefix, lookup.namespaceIndex);

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/BeanEnvironment.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/BeanEnvironment.java
@@ -36,11 +36,15 @@ public class BeanEnvironment {
     }
 
     public void loadDefinitions(ClassLoader loader) {
+        loadDefinitions(loader, true);
+    }
+
+    public void loadDefinitions(ClassLoader loader, boolean loadsFromParent) {
         if (beanLookup.containsKey(loader)) {
             return;
         }
         beanLookup.computeIfAbsent(loader, (ld) -> {
-            SoftServiceLoader<BeanDefinition> definitions = new SoftServiceLoader<>(BeanDefinition.class, ld);
+            SoftServiceLoader<BeanDefinition> definitions = new SoftServiceLoader<>(BeanDefinition.class, ld, loadsFromParent);
             ClassLookup lookup = new ClassLookup();
 
             List<ClassRef<?>> namespaceIndex = new ArrayList<>();

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/ClassIndex.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/ClassIndex.java
@@ -1,0 +1,9 @@
+package org.terasology.gestalt.di.index;
+
+import java.util.Set;
+
+public interface ClassIndex {
+    Set<String> getSubtypesOf(String clazzName);
+
+    Set<String> getTypesAnnotatedWith(String annotation);
+}

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/ClassIndex.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/ClassIndex.java
@@ -2,6 +2,10 @@ package org.terasology.gestalt.di.index;
 
 import java.util.Set;
 
+/**
+ * Index for classes, which provide `gestalt-di`.
+ * You should gather index via `gestalt-inject-java` annotation processing before use this class.
+ */
 public interface ClassIndex {
     Set<String> getSubtypesOf(String clazzName);
 

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/CompoundClassIndex.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/CompoundClassIndex.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Created for using multiple {@link ClassIndex} at once.
+ */
 public class CompoundClassIndex implements ClassIndex {
     private final List<ClassIndex> indexes;
 

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/CompoundClassIndex.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/CompoundClassIndex.java
@@ -1,0 +1,37 @@
+package org.terasology.gestalt.di.index;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class CompoundClassIndex implements ClassIndex {
+    private final List<ClassIndex> indexes;
+
+    public CompoundClassIndex(List<ClassIndex> indexes) {
+        this.indexes = indexes;
+    }
+
+    public CompoundClassIndex() {
+        this(Lists.newArrayList());
+    }
+
+    public void add(ClassIndex classIndex) {
+        indexes.add(classIndex);
+    }
+
+    @Override
+    public Set<String> getSubtypesOf(String clazzName) {
+        return indexes.stream()
+                .flatMap(classIndex -> classIndex.getSubtypesOf(clazzName).stream())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<String> getTypesAnnotatedWith(String annotation) {
+        return indexes.stream()
+                .flatMap(classIndex -> classIndex.getTypesAnnotatedWith(annotation).stream())
+                .collect(Collectors.toSet());
+    }
+}

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/PackagePrefixedUrlClassLoader.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/PackagePrefixedUrlClassLoader.java
@@ -1,0 +1,36 @@
+package org.terasology.gestalt.di.index;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PackagePrefixedUrlClassLoader extends UrlClassIndex {
+
+    private final String packagePrefix;
+
+    protected PackagePrefixedUrlClassLoader(URL url, String packagePrefix) {
+        super(url);
+        this.packagePrefix = packagePrefix;
+    }
+
+    @Override
+    protected Set<String> loadContent(String type, String target) {
+        try {
+            URL fullUrl = new URL(String.format("%s/%s/%s", getUrl(), type, target));
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(fullUrl.openStream()))) {
+                return reader.lines()
+                        .filter(line -> line.startsWith(packagePrefix))
+                        .collect(Collectors.toSet());
+            } catch (IOException e) {
+                return Collections.emptySet();
+            }
+        } catch (MalformedURLException e) {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/PackagePrefixedUrlClassLoader.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/PackagePrefixedUrlClassLoader.java
@@ -9,6 +9,9 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Loads only classes, which have concrete package prefix
+ */
 public class PackagePrefixedUrlClassLoader extends UrlClassIndex {
 
     private final String packagePrefix;

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/UrlClassIndex.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/UrlClassIndex.java
@@ -16,7 +16,7 @@ public class UrlClassIndex implements ClassIndex {
     private static final String ANNOTATIONS = "annotations";
     private final URL url;
 
-    private UrlClassIndex(URL url) {
+    protected UrlClassIndex(URL url) {
         this.url = url;
     }
 
@@ -44,8 +44,12 @@ public class UrlClassIndex implements ClassIndex {
         return new UrlClassIndex(Thread.currentThread().getContextClassLoader().getResource(METAINF));
     }
 
-    public static ClassIndex byClassLoaderPrefix(String packageName) { // TODO implement
-        return new UrlClassIndex(Thread.currentThread().getContextClassLoader().getResource(METAINF));
+    public static ClassIndex byClassLoaderPrefix(String packagePrefix) {
+        return new PackagePrefixedUrlClassLoader(Thread.currentThread().getContextClassLoader().getResource(METAINF), packagePrefix);
+    }
+
+    protected URL getUrl() {
+        return url;
     }
 
     @Override
@@ -58,7 +62,7 @@ public class UrlClassIndex implements ClassIndex {
         return loadContent(ANNOTATIONS, annotation);
     }
 
-    private Set<String> loadContent(String type, String target) {
+    protected Set<String> loadContent(String type, String target) {
         try {
             URL fullUrl = new URL(String.format("%s/%s/%s", url, type, target));
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(fullUrl.openStream()))) {

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/UrlClassIndex.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/UrlClassIndex.java
@@ -1,0 +1,73 @@
+package org.terasology.gestalt.di.index;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class UrlClassIndex implements ClassIndex {
+    private static final String METAINF = "META-INF";
+    private static final String SUBTYPES = "subtypes";
+    private static final String ANNOTATIONS = "annotations";
+    private final URL url;
+
+    private UrlClassIndex(URL url) {
+        this.url = url;
+    }
+
+    public static ClassIndex byDirectory(File file) {
+        try {
+            return new UrlClassIndex(new URL(file.toURI().toURL(), "/" + METAINF));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ClassIndex byArchive(File file) {
+        try {
+            return new UrlClassIndex(new URL(String.format("jar:file:///%s!/%s", file.getAbsolutePath(), METAINF)));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ClassIndex byClassLoader(ClassLoader classLoader) {
+        return new UrlClassIndex(classLoader.getResource(METAINF));
+    }
+
+    public static ClassIndex byClassLoader() {
+        return new UrlClassIndex(Thread.currentThread().getContextClassLoader().getResource(METAINF));
+    }
+
+    public static ClassIndex byClassLoaderPrefix(String packageName) { // TODO implement
+        return new UrlClassIndex(Thread.currentThread().getContextClassLoader().getResource(METAINF));
+    }
+
+    @Override
+    public Set<String> getSubtypesOf(String clazzName) {
+        return loadContent(SUBTYPES, clazzName);
+    }
+
+    @Override
+    public Set<String> getTypesAnnotatedWith(String annotation) {
+        return loadContent(ANNOTATIONS, annotation);
+    }
+
+    private Set<String> loadContent(String type, String target) {
+        try {
+            URL fullUrl = new URL(String.format("%s/%s/%s", url, type, target));
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(fullUrl.openStream()))) {
+                return reader.lines().collect(Collectors.toSet());
+            } catch (IOException e) {
+                return Collections.emptySet();
+            }
+        } catch (MalformedURLException e) {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/UrlClassIndex.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/UrlClassIndex.java
@@ -10,6 +10,13 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Load index from {@link URL}.
+ * <p>Can load index from:</p>
+ * <p>1. directory</p>
+ * <p>2. archive</p>
+ * <p>3. ClassLoader</p>
+ */
 public class UrlClassIndex implements ClassIndex {
     private static final String METAINF = "META-INF";
     private static final String SUBTYPES = "subtypes";

--- a/gestalt-di/src/test/java/org/terasology/gestalt/di/BeanEnvironmentTest.java
+++ b/gestalt-di/src/test/java/org/terasology/gestalt/di/BeanEnvironmentTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.module.TestImplementation1;
 import org.terasology.context.BeanDefinition;
 import org.terasology.gestalt.module.Module;
+import org.terasology.gestalt.module.ModuleFactory;
 import org.terasology.gestalt.module.ModulePathScanner;
 import org.terasology.gestalt.module.TableModuleRegistry;
 
@@ -31,7 +32,7 @@ public class BeanEnvironmentTest {
         environment = new BeanEnvironment();
         registry = new TableModuleRegistry();
 
-        new ModulePathScanner().scan(registry, Paths.get("test-modules").toFile());
+        new ModulePathScanner(new ModuleFactory()).scan(registry, Paths.get("test-modules").toFile());
         for (Iterator<Module> it = registry.iterator(); it.hasNext(); ) {
             Module m = it.next();
             URL[] urls = m.getClasspaths().stream().map(x -> {

--- a/gestalt-entity-system/build.gradle
+++ b/gestalt-entity-system/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation project(":gestalt-util")
     implementation project(":gestalt-module")
     implementation project(":gestalt-asset-core")
+    implementation project(":gestalt-inject")
+    annotationProcessor project(":gestalt-inject-java")
 
     implementation "com.google.guava:guava:$guava_version"
     implementation "org.slf4j:slf4j-api:$slf4j_version"
@@ -37,10 +39,21 @@ dependencies {
     implementation 'net.sf.trove4j:trove4j:3.0.3'
     implementation "com.google.code.gson:gson:$gson_version"
 
+    testAnnotationProcessor project(":gestalt-inject-java")
     testImplementation "junit:junit:$junit_version"
     testImplementation "ch.qos.logback:logback-classic:$logback_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"
 }
+
+compileJava {
+    inputs.files sourceSets.main.resources.srcDirs
+    options.compilerArgs = ["-Aresource=${sourceSets.main.resources.srcDirs.join(File.pathSeparator)}"]
+}
+compileTestJava {
+    inputs.files sourceSets.test.resources.srcDirs
+    options.compilerArgs = ["-Aresource=${sourceSets.test.resources.srcDirs.join(File.pathSeparator)}"]
+}
+
 
 buildscript {
     repositories {

--- a/gestalt-entity-system/build.gradle
+++ b/gestalt-entity-system/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation project(":gestalt-module")
     implementation project(":gestalt-asset-core")
 
-    implementation "com.google.guava:guava:$guava_version" // TODO remove it
+    implementation "com.google.guava:guava:$guava_version"
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
     implementation "net.jcip:jcip-annotations:$jcip_annotation_version"

--- a/gestalt-entity-system/build.gradle
+++ b/gestalt-entity-system/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation project(":gestalt-module")
     implementation project(":gestalt-asset-core")
 
+    implementation "com.google.guava:guava:$guava_version" // TODO remove it
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
     implementation "net.jcip:jcip-annotations:$jcip_annotation_version"

--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/Component.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/Component.java
@@ -16,6 +16,8 @@
 
 package org.terasology.gestalt.entitysystem.component;
 
+import org.terasology.context.annotation.IndexInherited;
+
 /**
  * A component is an element that can be added to an entity. A component holds data, and implies a feature or behavior of the entity.
  * <p>
@@ -28,6 +30,7 @@ package org.terasology.gestalt.entitysystem.component;
  * you have two components with similar configuration requirements but different behavior. Note that the entity system does not take into consideration
  * inheritance - you cannot retrieve components via a super type - so and shared inheritance is much like private inheritance in C++.
  */
+@IndexInherited
 public interface Component<T extends Component> {
 
     /**

--- a/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/component/management/ComponentTypeIndexTest.java
+++ b/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/component/management/ComponentTypeIndexTest.java
@@ -16,8 +16,8 @@
 
 package org.terasology.gestalt.entitysystem.component.management;
 
+import modules.test.components.Sample;
 import org.junit.Test;
-import org.reflections.util.ClasspathHelper;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
@@ -27,8 +27,6 @@ import org.terasology.gestalt.naming.Name;
 
 import java.util.Collections;
 import java.util.Optional;
-
-import modules.test.components.Sample;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,7 +38,7 @@ public class ComponentTypeIndexTest {
     private ComponentTypeIndex index;
 
     public ComponentTypeIndexTest() throws Exception {
-        ModuleFactory factory = new ModuleFactory(ClasspathHelper.staticClassLoader());
+        ModuleFactory factory = new ModuleFactory();
         Module module = factory.createPackageModule("modules.test");
         ModuleEnvironment moduleEnvironment = new ModuleEnvironment(Collections.singletonList(module), new PermitAllPermissionProviderFactory());
         index = new ComponentTypeIndex(moduleEnvironment);

--- a/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/component/management/ComponentTypeIndexTest.java
+++ b/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/component/management/ComponentTypeIndexTest.java
@@ -19,6 +19,7 @@ package org.terasology.gestalt.entitysystem.component.management;
 import modules.test.components.Sample;
 import org.junit.Test;
 import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.ModuleFactory;
@@ -40,7 +41,7 @@ public class ComponentTypeIndexTest {
     public ComponentTypeIndexTest() throws Exception {
         ModuleFactory factory = new ModuleFactory();
         Module module = factory.createPackageModule("modules.test");
-        ModuleEnvironment moduleEnvironment = new ModuleEnvironment(Collections.singletonList(module), new PermitAllPermissionProviderFactory());
+        ModuleEnvironment moduleEnvironment = new ModuleEnvironment(new DefaultBeanContext(), Collections.singletonList(module), new PermitAllPermissionProviderFactory());
         index = new ComponentTypeIndex(moduleEnvironment);
     }
 

--- a/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/entity/FullSetupExample.java
+++ b/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/entity/FullSetupExample.java
@@ -18,9 +18,12 @@ package org.terasology.gestalt.entitysystem.entity;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
+import modules.test.components.BasicComponent;
+import modules.test.components.Empty;
+import modules.test.components.Second;
 import org.junit.Before;
 import org.junit.Test;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.entitysystem.component.Component;
 import org.terasology.gestalt.entitysystem.component.management.ComponentManager;
 import org.terasology.gestalt.entitysystem.component.store.ArrayComponentStore;
@@ -41,10 +44,6 @@ import org.terasology.gestalt.naming.Version;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Set;
-
-import modules.test.components.BasicComponent;
-import modules.test.components.Empty;
-import modules.test.components.Second;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -75,7 +74,7 @@ public class FullSetupExample {
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.lang");
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("org.terasology");
 
-        ModuleEnvironment environment = new ModuleEnvironment(moduleRegistry, new WarnOnlyProviderFactory(permissionProviderFactory), JavaModuleClassLoader::create);
+        ModuleEnvironment environment = new ModuleEnvironment(new DefaultBeanContext(), moduleRegistry, new WarnOnlyProviderFactory(permissionProviderFactory), JavaModuleClassLoader::create);
 
         // Create component stores. This gives an opportunity to set some component types to use ArrayComponentStore
         ComponentManager componentManager = new ComponentManager();

--- a/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/prefab/PrefabJsonFormatTest.java
+++ b/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/prefab/PrefabJsonFormatTest.java
@@ -16,6 +16,8 @@
 
 package org.terasology.gestalt.entitysystem.prefab;
 
+import modules.test.components.Reference;
+import modules.test.components.Sample;
 import org.junit.Test;
 import org.terasology.gestalt.assets.AssetType;
 import org.terasology.gestalt.assets.ResourceUrn;
@@ -25,6 +27,7 @@ import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManager;
 import org.terasology.gestalt.assets.module.ModuleAwareAssetTypeManagerImpl;
 import org.terasology.gestalt.assets.module.ModuleDependencyResolutionStrategy;
 import org.terasology.gestalt.assets.module.ModuleEnvironmentDependencyProvider;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.entitysystem.component.management.ComponentManager;
 import org.terasology.gestalt.entitysystem.component.management.ComponentTypeIndex;
 import org.terasology.gestalt.module.Module;
@@ -34,9 +37,6 @@ import org.terasology.gestalt.module.sandbox.PermitAllPermissionProviderFactory;
 
 import java.util.Collections;
 import java.util.Optional;
-
-import modules.test.components.Reference;
-import modules.test.components.Sample;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -72,7 +72,7 @@ public class PrefabJsonFormatTest {
     public PrefabJsonFormatTest() throws Exception {
         ModuleFactory factory = new ModuleFactory();
         Module module = factory.createPackageModule("modules.test");
-        ModuleEnvironment moduleEnvironment = new ModuleEnvironment(Collections.singletonList(module), new PermitAllPermissionProviderFactory());
+        ModuleEnvironment moduleEnvironment = new ModuleEnvironment(new DefaultBeanContext(), Collections.singletonList(module), new PermitAllPermissionProviderFactory());
 
         componentManager = new ComponentManager();
         AssetType<Prefab, PrefabData> prefabAssetType = assetTypeManager.createAssetType(Prefab.class, Prefab::new, "prefabs");

--- a/gestalt-es-perf/build.gradle
+++ b/gestalt-es-perf/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation project(":gestalt-asset-core")
 	implementation project(":gestalt-entity-system")
 
+    implementation "com.google.guava:guava:$guava_version"
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
     implementation "net.jcip:jcip-annotations:$jcip_annotation_version"

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/AnnotationTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/AnnotationTypeWriter.java
@@ -1,0 +1,42 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.gestalt.annotation.processing;
+
+import javax.annotation.processing.Filer;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class AnnotationTypeWriter {
+    private static final String META_INF = "META-INF" + File.separator + "annotations";
+
+    private final Filer filer;
+    private final Map<String, HashSet<String>> results = new HashMap<>();
+    private final Map<String, FileObject> files = new HashMap<>();
+
+    public AnnotationTypeWriter(Filer filer) {
+        this.filer = filer;
+    }
+
+    public void writeAnnotation(String service, String target) {
+        results.putIfAbsent(service, new HashSet<>());
+        results.get(service).add(target);
+    }
+
+    public void finish() throws IOException {
+        for (Map.Entry<String, HashSet<String>> pair : results.entrySet()) {
+            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + File.separator + pair.getKey());
+            try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
+                for (String clazz : pair.getValue()) {
+                    writer.write(clazz);
+                    writer.newLine();
+                }
+            }
+        }
+    }
+}

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
@@ -1,5 +1,6 @@
 package org.terasology.gestalt.annotation.processing;
 
+import com.google.common.collect.Queues;
 import org.terasology.context.annotation.Index;
 import org.terasology.context.annotation.IndexInherited;
 
@@ -11,10 +12,13 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Queue;
 import java.util.Set;
 
 public class ClassIndexProcessor extends AbstractProcessor {
@@ -38,37 +42,80 @@ public class ClassIndexProcessor extends AbstractProcessor {
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         for (TypeElement annotation : annotations) {
             // Annotation Index
-            if (elementUtility.hasStereotype(annotation, Collections.singletonList(Index.class.getName()))) {
-                for (Element type : roundEnv.getElementsAnnotatedWith(annotation)) {
-                    if (type.getKind() == ElementKind.CLASS) {
-                        annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), type.asType().toString());
-                    } else if (type.getKind() == ElementKind.PACKAGE) {
-                        PackageElement packageType = (PackageElement) type;
-                        for (Element enclosedElement : packageType.getEnclosedElements()) {
-                            annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), enclosedElement.asType().toString());
-                        }
-                    }
-                }
-            }
-            if (Arrays.asList(Index.class.getName(), IndexInherited.class.getName()).contains(annotation)) {
-                for (Element type : roundEnv.getElementsAnnotatedWith(annotation)) {
-                    if (type.getKind() == ElementKind.CLASS) {
-                        for (TypeMirror tm : ((TypeElement) type).getInterfaces()) {
-                            subtypesTypeWriter.writeSubType(tm.toString(), type.asType().toString());
-                        }
-                    }
-                }
-            }
+            processAnnotationIndex(roundEnv, annotation);
+            // Subtypes index. classes under index.
+            processSubtypeIndexByDirectMarked(roundEnv, annotation);
         }
+        // Subtypes index. every class, which can have interface with `@IndexInherited` annotation.
+        processSubtypeIndexInReverseWay(roundEnv);
+
         if (roundEnv.processingOver()) {
-            try {
-                annotationTypeWriter.finish();
-                subtypesTypeWriter.finish();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            writeIndexes();
         }
         return false;
+    }
+
+    private void processSubtypeIndexInReverseWay(RoundEnvironment roundEnv) {
+        for (Element type : roundEnv.getRootElements()) {
+            Queue<TypeMirror> supers = Queues.newArrayDeque();
+            if (type.getKind() == ElementKind.CLASS) {
+                supers.addAll(elementUtility.getTypes().directSupertypes(type.asType()));
+                while (!supers.isEmpty()) {
+                    TypeMirror candidate = supers.poll();
+                    if (candidate.getKind() != TypeKind.NONE) {
+                        if (elementUtility.hasStereotype(elementUtility.getTypes().asElement(candidate),
+                                Collections.singletonList(IndexInherited.class.getName())))
+                            subtypesTypeWriter.writeSubType(elementUtility.getTypes().erasure(candidate).toString(), type.asType().toString());
+                        supers.addAll(elementUtility.getTypes().directSupertypes(candidate));
+                    }
+                }
+            }
+        }
+    }
+
+    private void processSubtypeIndexByDirectMarked(RoundEnvironment roundEnv, TypeElement annotation) {
+        if (Arrays.asList(Index.class.getName(), IndexInherited.class.getName()).contains(annotation.asType().toString())) {
+            for (Element type : roundEnv.getElementsAnnotatedWith(annotation)) {
+                if (type.getKind() == ElementKind.CLASS) {
+                    TypeElement typeElement = (TypeElement) type;
+                    Queue<TypeMirror> supers = Queues.newArrayDeque();
+                    supers.addAll(elementUtility.getTypes().directSupertypes(typeElement.asType()));
+                    while (!supers.isEmpty()) {
+                        TypeMirror candidate = supers.poll();
+                        if (candidate.getKind() != TypeKind.NONE) {
+                            if (elementUtility.hasStereotype(elementUtility.getTypes().asElement(candidate),
+                                    Collections.singletonList(IndexInherited.class.getName())))
+                                subtypesTypeWriter.writeSubType(elementUtility.getTypes().erasure(candidate).toString(), type.asType().toString());
+                            supers.addAll(elementUtility.getTypes().directSupertypes(candidate));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void processAnnotationIndex(RoundEnvironment roundEnv, TypeElement annotation) {
+        if (elementUtility.hasStereotype(annotation, Collections.singletonList(Index.class.getName()))) {
+            for (Element type : roundEnv.getElementsAnnotatedWith(annotation)) {
+                if (type.getKind() == ElementKind.CLASS) {
+                    annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), type.asType().toString());
+                } else if (type.getKind() == ElementKind.PACKAGE) {
+                    PackageElement packageType = (PackageElement) type;
+                    for (Element enclosedElement : packageType.getEnclosedElements()) {
+                        annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), enclosedElement.asType().toString());
+                    }
+                }
+            }
+        }
+    }
+
+    private void writeIndexes() {
+        try {
+            annotationTypeWriter.finish();
+            subtypesTypeWriter.finish();
+        } catch (IOException e) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Cannot write indexes: " + e.getMessage());
+        }
     }
 
     @Override

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
@@ -1,0 +1,78 @@
+package org.terasology.gestalt.annotation.processing;
+
+import org.terasology.context.annotation.Index;
+import org.terasology.context.annotation.IndexInherited;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+public class ClassIndexProcessor extends AbstractProcessor {
+
+
+    private Filer filer;
+    private AnnotationTypeWriter annotationTypeWriter;
+    private SubtypesTypeWriter subtypesTypeWriter;
+    private ElementUtility elementUtility;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        filer = processingEnv.getFiler();
+        annotationTypeWriter = new AnnotationTypeWriter(filer);
+        subtypesTypeWriter = new SubtypesTypeWriter(filer);
+        elementUtility = new ElementUtility(processingEnv.getElementUtils(), processingEnv.getTypeUtils());
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (TypeElement annotation : annotations) {
+            // Annotation Index
+            if (elementUtility.hasStereotype(annotation, Collections.singletonList(Index.class.getName()))) {
+                for (Element type : roundEnv.getElementsAnnotatedWith(annotation)) {
+                    if (type.getKind() == ElementKind.CLASS) {
+                        annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), type.asType().toString());
+                    } else if (type.getKind() == ElementKind.PACKAGE) {
+                        PackageElement packageType = (PackageElement) type;
+                        for (Element enclosedElement : packageType.getEnclosedElements()) {
+                            annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), enclosedElement.asType().toString());
+                        }
+                    }
+                }
+            }
+            if (Arrays.asList(Index.class.getName(), IndexInherited.class.getName()).contains(annotation)) {
+                for (Element type : roundEnv.getElementsAnnotatedWith(annotation)) {
+                    if (type.getKind() == ElementKind.CLASS) {
+                        for (TypeMirror tm : ((TypeElement) type).getInterfaces()) {
+                            subtypesTypeWriter.writeSubType(tm.toString(), type.asType().toString());
+                        }
+                    }
+                }
+            }
+        }
+        if (roundEnv.processingOver()) {
+            try {
+                annotationTypeWriter.finish();
+                subtypesTypeWriter.finish();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Collections.singleton("*");
+    }
+}

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
@@ -1,0 +1,59 @@
+package org.terasology.gestalt.annotation.processing;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@SupportedOptions("resource")
+public class ResourceProcessor extends AbstractProcessor {
+    private static final String FILE = "META-INF" + File.separator + "resources";
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Collections.singleton("*");
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) {
+            String path = processingEnv.getOptions().get("resource");
+            if (path != null) {
+                try {
+                    Path root = Paths.get(path);
+                    if (root.toFile().exists()) {
+                        List<String> files = Files.walk(root)
+                                .map(root::relativize)
+                                .map(Objects::toString)
+                                .filter(str -> !str.endsWith(".class"))
+                                .filter(str -> !str.isEmpty())
+                                .collect(Collectors.toList());
+                        FileObject fileObject = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", FILE);
+                        try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
+                            for (String clazz : files) {
+                                writer.write(clazz);
+                                writer.newLine();
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/SubtypesTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/SubtypesTypeWriter.java
@@ -1,0 +1,43 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.gestalt.annotation.processing;
+
+import javax.annotation.processing.Filer;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class SubtypesTypeWriter {
+    private static final String META_INF = "META-INF" + File.separator + "subtypes";
+
+    private final Filer filer;
+    private final Map<String, HashSet<String>> results = new HashMap<>();
+    private final Map<String, FileObject> files = new HashMap<>();
+
+    public SubtypesTypeWriter(Filer filer) {
+        this.filer = filer;
+    }
+
+    public void writeSubType(String type, String subtype) {
+        results.putIfAbsent(type, new HashSet<>());
+        results.get(type).add(subtype);
+    }
+
+    public void finish() throws IOException {
+        for (Map.Entry<String, HashSet<String>> pair : results.entrySet()) {
+            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + File.separator + pair.getKey());
+            try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
+                for (String clazz : pair.getValue()) {
+                    writer.write(clazz);
+                    writer.newLine();
+                }
+            }
+
+        }
+    }
+}

--- a/gestalt-inject-java/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/gestalt-inject-java/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,2 @@
 org.terasology.gestalt.annotation.processing.BeanDefinitionProcessor
+org.terasology.gestalt.annotation.processing.ClassIndexProcessor

--- a/gestalt-inject-java/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/gestalt-inject-java/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,2 +1,3 @@
 org.terasology.gestalt.annotation.processing.BeanDefinitionProcessor
 org.terasology.gestalt.annotation.processing.ClassIndexProcessor
+org.terasology.gestalt.annotation.processing.ResourceProcessor

--- a/gestalt-inject/src/main/java/org/terasology/context/SoftServiceLoader.java
+++ b/gestalt-inject/src/main/java/org/terasology/context/SoftServiceLoader.java
@@ -2,31 +2,47 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.context;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class SoftServiceLoader<S> implements Iterable<S> {
     public static final String META_INF_SERVICES = "META-INF/services";
+    private static final Logger logger = LoggerFactory.getLogger(SoftServiceLoader.class);
 
     private final Class<S> target;
     private final ClassLoader classLoader;
+    private final boolean loadsFromParent;
 
     public SoftServiceLoader(Class<S> target, ClassLoader classLoader) {
-        this.target = target;
-        this.classLoader = classLoader;
+        this(target, classLoader, true);
     }
 
-    public static <S> SoftServiceLoader<S> ThreadLocal(Class<S> target) {
+    public SoftServiceLoader(Class<S> target, ClassLoader classLoader, boolean loadsFromParent) {
+        Preconditions.checkArgument(loadsFromParent || classLoader instanceof URLClassLoader,
+                "loadsFromParent == false implemented for UrlClassLoader only");
+        this.target = target;
+        this.classLoader = classLoader;
+        this.loadsFromParent = loadsFromParent;
+    }
+
+    public static <S> SoftServiceLoader<S> threadLocal(Class<S> target) {
         return new SoftServiceLoader<>(target, SoftServiceLoader.class.getClassLoader());
     }
 
@@ -34,58 +50,82 @@ public class SoftServiceLoader<S> implements Iterable<S> {
     @Nonnull
     public Iterator<S> iterator() {
         try {
-            Enumeration<URL> urls = classLoader.getResources(META_INF_SERVICES + '/' + target.getName());
-            return new Iterator<S>() {
-                private Iterator<String> nameIterator = Collections.emptyIterator();
-                @Override
-                public boolean hasNext() {
-                    if(nameIterator.hasNext()) {
-                        return true;
-                    }
-                    if(urls.hasMoreElements()) {
-                        while (!nameIterator.hasNext()) {
-                            URL url = urls.nextElement();
-                            try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
-
-                                List<String> lines = reader.lines()
-                                    .filter(line -> line.length() != 0 && line.charAt(0) != '#')
-                                    .map(line -> {
-                                        int i = line.indexOf('#');
-                                        if (i > -1) {
-                                            return line.substring(0, i);
-                                        }
-                                        return line;
-                                    }).collect(Collectors.toList());
-
-                                nameIterator = lines.listIterator();
-                            } catch (IOException e) {
-
-                            }
-                        }
-                        return true;
-                    }
-                    return false;
-                }
-
-                @Override
-                public S next() {
-                    if (!hasNext()) {
-                        throw new NoSuchElementException();
-                    }
-                    String clazz = nameIterator.next();
-                    try {
-                        return (S) classLoader.loadClass(clazz).getDeclaredConstructor().newInstance();
-                    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
-                        e.printStackTrace();
-                    }
-                    return null;
-                }
-            };
+            Enumeration<URL> urls;
+            if (!loadsFromParent && classLoader instanceof URLClassLoader) {
+                urls = ((URLClassLoader) classLoader).findResources(META_INF_SERVICES + '/' + target.getName());
+            } else {
+                urls = classLoader.getResources(META_INF_SERVICES + '/' + target.getName());
+            }
+            return Iterators.filter(new ServiceIterator(urls, target.getName()), Objects::nonNull);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Cannot iterate [{}]", META_INF_SERVICES + '/' + target.getName(), e);
         }
         return Collections.emptyIterator();
     }
 
 
+    private class ServiceIterator implements Iterator<S> {
+        private final Enumeration<URL> urls;
+        private final String targetClass;
+        private Iterator<String> nameIterator;
+
+        public ServiceIterator(Enumeration<URL> urls, String targetClass) {
+            this.urls = urls;
+            nameIterator = Collections.emptyIterator();
+            this.targetClass = targetClass;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (nameIterator.hasNext()) {
+                return true;
+            }
+            if (urls.hasMoreElements()) {
+                while (!nameIterator.hasNext()) {
+                    URL url = urls.nextElement();
+                    switchNameIteratorTo(url);
+                }
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public S next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            String className = nameIterator.next();
+            try {
+                Class<?> clazz = classLoader.loadClass(className);
+                if (clazz != null) {
+                    return (S) clazz.getDeclaredConstructor().newInstance();
+                } else {
+                    logger.warn("Cannot receive {}'s service: [{}]", targetClass, className);
+                    return null;
+                }
+            } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
+                logger.warn("Cannot create {}'s service", targetClass, e);
+            }
+            return null;
+        }
+
+        private void switchNameIteratorTo(URL url) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+                List<String> lines = reader.lines()
+                        .filter(line -> line.length() != 0 && line.charAt(0) != '#')
+                        .map(line -> {
+                            int i = line.indexOf('#');
+                            if (i > -1) {
+                                return line.substring(0, i);
+                            }
+                            return line;
+                        }).collect(Collectors.toList());
+
+                nameIterator = lines.listIterator();
+            } catch (IOException e) {
+                logger.warn("Cannot read {}'s services", targetClass, e);
+            }
+        }
+    }
 }

--- a/gestalt-inject/src/main/java/org/terasology/context/annotation/API.java
+++ b/gestalt-inject/src/main/java/org/terasology/context/annotation/API.java
@@ -15,6 +15,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.PACKAGE})
 @Documented
+@Index
 public @interface API {
 
     /**

--- a/gestalt-inject/src/main/java/org/terasology/context/annotation/Index.java
+++ b/gestalt-inject/src/main/java/org/terasology/context/annotation/Index.java
@@ -1,0 +1,16 @@
+package org.terasology.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotatation for indexing classes.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+public @interface Index {
+}

--- a/gestalt-inject/src/main/java/org/terasology/context/annotation/IndexInherited.java
+++ b/gestalt-inject/src/main/java/org/terasology/context/annotation/IndexInherited.java
@@ -1,0 +1,19 @@
+package org.terasology.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotatation for indexing classes. Inherited version.
+ * Don't works at annotations.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+@Inherited
+public @interface IndexInherited {
+}

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -54,9 +54,11 @@ dependencies {
 }
 
 compileJava {
+    inputs.files sourceSets.main.resources.srcDirs
     options.compilerArgs = ["-Aresource=${sourceSets.main.resources.srcDirs.join(File.pathSeparator)}"]
 }
 compileTestJava {
+    inputs.files sourceSets.test.resources.srcDirs
     options.compilerArgs = ["-Aresource=${sourceSets.test.resources.srcDirs.join(File.pathSeparator)}"]
 }
 

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -51,8 +51,15 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     testImplementation "ch.qos.logback:logback-classic:$logback_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"
-
 }
+
+compileJava {
+    options.compilerArgs = ["-Aresource=${sourceSets.main.resources.srcDirs[0]}"]
+}
+compileTestJava {
+    options.compilerArgs = ["-Aresource=${sourceSets.test.resources.srcDirs[0]}"]
+}
+
 
 // Library and distribution config
 description = 'Provides support for modules - java libraries that can be activated at runtime and run in a sandboxed environment'

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -54,10 +54,10 @@ dependencies {
 }
 
 compileJava {
-    options.compilerArgs = ["-Aresource=${sourceSets.main.resources.srcDirs[0]}"]
+    options.compilerArgs = ["-Aresource=${sourceSets.main.resources.srcDirs.join(File.pathSeparator)}"]
 }
 compileTestJava {
-    options.compilerArgs = ["-Aresource=${sourceSets.test.resources.srcDirs[0]}"]
+    options.compilerArgs = ["-Aresource=${sourceSets.test.resources.srcDirs.join(File.pathSeparator)}"]
 }
 
 

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -32,10 +32,13 @@ repositories {
 
 // Primary dependencies definition
 dependencies {
-    api 'org.terasology:reflections:0.9.12-MB'
-
+    implementation "org.javassist:javassist:3.27.0-GA" // TODO REMOVE this. replaces with gestalt's di generator.
+    
     implementation project(":gestalt-util")
     implementation project(":gestalt-inject")
+    implementation project(":gestalt-di")
+    annotationProcessor project(":gestalt-inject-java")
+
     implementation "com.google.guava:guava:$guava_version"
     implementation "com.google.code.gson:gson:$gson_version"
     implementation 'org.apache.commons:commons-vfs2:2.2'
@@ -44,6 +47,7 @@ dependencies {
     implementation "com.github.zafarkhaja:java-semver:0.10.0"
 
     testImplementation project(":testpack:testpack-api")
+    testAnnotationProcessor project(":gestalt-inject-java")
     testImplementation "junit:junit:$junit_version"
     testImplementation "ch.qos.logback:logback-classic:$logback_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -33,10 +33,11 @@ repositories {
 // Primary dependencies definition
 dependencies {
     implementation "org.javassist:javassist:3.27.0-GA" // TODO REMOVE this. replaces with gestalt's di generator.
-    
+
+    api project(":gestalt-di")
+
     implementation project(":gestalt-util")
     implementation project(":gestalt-inject")
-    implementation project(":gestalt-di")
     annotationProcessor project(":gestalt-inject-java")
 
     implementation "com.google.guava:guava:$guava_version"

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/Module.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/Module.java
@@ -18,10 +18,9 @@ package org.terasology.gestalt.module;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
-import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.gestalt.di.index.ClassIndex;
 import org.terasology.gestalt.module.resources.ModuleFileSource;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.Version;
@@ -47,7 +46,7 @@ public final class Module {
     private final ImmutableList<File> moduleClasspaths;
     private final Predicate<Class<?>> classPredicate;
 
-    private final Reflections moduleManifest;
+    private final ClassIndex classIndex;
 
     /**
      * Creates a module composed of the given paths, classpaths, and described by the given metadata.
@@ -55,22 +54,20 @@ public final class Module {
      * @param metadata       The metadata describing the module
      * @param fileSources    Any sources of files that compose the module. Must not be null - can be {@link org.terasology.gestalt.module.resources.EmptyFileSource}
      * @param classpaths     Any extra classpaths to load for the module
-     * @param moduleManifest A manifest of the contents of the module. This should indicate all classes and any classpath provided resources.
+     * @param classIndex     A manifest of the contents of the module. This should indicate all classes and any classpath provided resources.
      *                       Additionally this provides additional information on classes such as what they inherit and what annotations they are flagged with.
      * @param classPredicate Predicate to determine what classes to include from the main classpath (classes from the unloaded classpaths will be included automatically)
      */
-    public Module(ModuleMetadata metadata, ModuleFileSource fileSources, Collection<File> classpaths, Reflections moduleManifest, Predicate<Class<?>> classPredicate) {
+    public Module(ModuleMetadata metadata, ModuleFileSource fileSources, Collection<File> classpaths, ClassIndex classIndex, Predicate<Class<?>> classPredicate) {
         Preconditions.checkNotNull(metadata);
         Preconditions.checkNotNull(fileSources);
-        Preconditions.checkNotNull(moduleManifest);
+        Preconditions.checkNotNull(classIndex);
         Preconditions.checkNotNull(classPredicate);
         this.metadata = metadata;
         this.moduleFileSources = fileSources;
         this.moduleClasspaths = ImmutableList.copyOf(classpaths);
         this.classPredicate = classPredicate;
-        this.moduleManifest = moduleManifest;
-        // Sometimes reflections loses the Resources store if it is empty? Debugging still, but this prevents it from breaking everything
-        moduleManifest.getStore().getOrCreate("ResourcesScanner");
+        this.classIndex = classIndex;
     }
 
     /**
@@ -118,8 +115,8 @@ public final class Module {
     /**
      * @return Information on the contents on this module
      */
-    public Reflections getModuleManifest() {
-        return moduleManifest;
+    public ClassIndex getClassIndex() {
+        return classIndex;
     }
 
     /**

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleEnvironment.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleEnvironment.java
@@ -17,7 +17,6 @@
 package org.terasology.gestalt.module;
 
 import android.support.annotation.NonNull;
-
 import com.google.common.collect.Collections2;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -26,13 +25,9 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
-
-import org.reflections.Reflections;
-import org.reflections.ReflectionsException;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.gestalt.di.index.ClassIndex;
 import org.terasology.gestalt.module.dependencyresolution.DependencyInfo;
 import org.terasology.gestalt.module.resources.CompositeFileSource;
 import org.terasology.gestalt.module.resources.ModuleFileSource;
@@ -56,8 +51,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static org.reflections.util.Utils.index;
-
 /**
  * An environment composed of a set of modules. A chain of class loaders is created for each module that isn't on the classpath, such that dependencies appear before
  * dependants. Classes of interest can then be discovered by the types they inherit or annotations they have.
@@ -76,8 +69,10 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
     private final ClassLoader apiClassLoader;
     private final ClassLoader finalClassLoader;
     private final ImmutableList<ModuleClassLoader> managedClassLoaders;
+
     private final ImmutableSetMultimap<Name, Name> moduleDependencies;
-    private final Reflections fullReflections;
+    private final Map<Name, ClassIndex> classIndexByModule;
+    private final Map<Name, ClassLoader> classLoaderByModule;
     private final ImmutableList<Module> modulesOrderByDependencies;
     private final ImmutableList<Name> moduleIdsOrderedByDependencies;
     private final ModuleFileSource resources;
@@ -109,33 +104,41 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
      * @throws java.lang.IllegalArgumentException if the Iterable contains multiple modules with the same id.
      */
     public ModuleEnvironment(Iterable<Module> modules, final PermissionProviderFactory permissionProviderFactory, ClassLoaderSupplier classLoaderSupplier, ClassLoader apiClassLoader) {
-        Map<Name, Reflections> reflectionsByModule = Maps.newLinkedHashMap();
+
         this.modules = buildModuleMap(modules);
         this.apiClassLoader = apiClassLoader;
         this.modulesOrderByDependencies = calculateModulesOrderedByDependencies();
         this.moduleIdsOrderedByDependencies = ImmutableList.copyOf(Collections2.transform(modulesOrderByDependencies, Module::getId));
 
+        Map<Name, ClassIndex> classIndexByModule = Maps.newLinkedHashMap();
+        Map<Name, ClassLoader> classLoaderByModule = Maps.newLinkedHashMap();
         ImmutableList.Builder<ModuleClassLoader> managedClassLoaderListBuilder = ImmutableList.builder();
         ClassLoader lastClassLoader = apiClassLoader;
         List<Module> orderedModules = getModulesOrderedByDependencies();
         Predicate<Class<?>> classpathModuleClassesPredicate = orderedModules.stream().map(Module::getClassPredicate).reduce(x -> false, Predicate::or);
         for (final Module module : orderedModules) {
-            if (!module.getClasspaths().isEmpty() && !hasClassContent(module)) {
+            // TODO return non-code module handling.
+
+            if (!module.getClasspaths().isEmpty()) {
+                // Directory and archive modules
                 ModuleClassLoader classLoader = buildModuleClassLoader(module, lastClassLoader, permissionProviderFactory, classLoaderSupplier, classpathModuleClassesPredicate);
                 managedClassLoaderListBuilder.add(classLoader);
                 lastClassLoader = classLoader.getClassLoader();
+                classIndexByModule.put(module.getId(), module.getClassIndex());
+                classLoaderByModule.put(module.getId(), classLoader.getClassLoader());
+            } else {
+                // Package modules
+                classIndexByModule.put(module.getId(), module.getClassIndex());
+                classLoaderByModule.put(module.getId(), apiClassLoader);
             }
-            reflectionsByModule.put(module.getId(), module.getModuleManifest());
+            // Ignoring resources
         }
         this.finalClassLoader = lastClassLoader;
-        this.fullReflections = buildFullReflections(reflectionsByModule);
+        this.classIndexByModule = classIndexByModule;
+        this.classLoaderByModule = classLoaderByModule;
         this.managedClassLoaders = managedClassLoaderListBuilder.build();
         this.moduleDependencies = buildModuleDependencies();
         this.resources = new CompositeFileSource(getModulesOrderedByDependencies().stream().map(Module::getResources).collect(Collectors.toList()));
-    }
-
-    private boolean hasClassContent(Module module) {
-        return module.getModuleManifest().getStore().getAll(index(SubTypesScanner.class), Object.class.getName()).iterator().hasNext();
     }
 
     /**
@@ -164,21 +167,6 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
                                                      final Predicate<Class<?>> classpathModuleClassesPredicate) {
         PermissionProvider permissionProvider = permissionProviderFactory.createPermissionProviderFor(module, classpathModuleClassesPredicate);
         return AccessController.doPrivileged((PrivilegedAction<ModuleClassLoader>) () -> classLoaderSupplier.create(module, parent, permissionProvider));
-    }
-
-    /**
-     * Builds Reflections information over the entire module environment, combining the information of all individual modules
-     *
-     * @param reflectionsByModule A map of reflection information for each module
-     */
-    private Reflections buildFullReflections(Map<Name, Reflections> reflectionsByModule) {
-        ConfigurationBuilder fullBuilder = new ConfigurationBuilder()
-                .addClassLoader(finalClassLoader);
-        Reflections reflections = new Reflections(fullBuilder);
-        for (Reflections moduleReflection : reflectionsByModule.values()) {
-            reflections.merge(moduleReflection);
-        }
-        return reflections;
     }
 
     private ImmutableSetMultimap<Name, Name> buildModuleDependencies() {
@@ -291,11 +279,12 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
      * @return A Iterable over all subtypes of type that appear in the module environment
      */
     public <U> Iterable<Class<? extends U>> getSubtypesOf(Class<U> type) {
-        try {
-            return fullReflections.getSubTypesOf(type);
-        } catch (ReflectionsException e) {
-            throw new ReflectionsException("Could not obtain subtypes of '" + type + "' - possible subclass without permission", e);
-        }
+        return classIndexByModule.entrySet().stream()
+                .flatMap(entry -> entry.getValue().getSubtypesOf(type.getName())
+                        .stream()
+                        .map(clazzName -> (Class<? extends U>) loadClass(classLoaderByModule.get(entry.getKey()), clazzName))
+                ).filter(Objects::nonNull)
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -305,7 +294,13 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
      * @return A Iterable over all subtypes of type that appear in the module environment
      */
     public <U> Iterable<Class<? extends U>> getSubtypesOf(Class<U> type, Predicate<Class<?>> filter) {
-        return fullReflections.getSubTypesOf(type).stream().filter(filter).collect(Collectors.toSet());
+        return classIndexByModule.entrySet().stream()
+                .flatMap(entry -> entry.getValue().getSubtypesOf(type.getName())
+                        .stream()
+                        .map(clazzName -> (Class<? extends U>) loadClass(classLoaderByModule.get(entry.getKey()), clazzName))
+                ).filter(Objects::nonNull)
+                .filter(filter)
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -314,7 +309,12 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
      * as @Inherited
      */
     public Iterable<Class<?>> getTypesAnnotatedWith(Class<? extends Annotation> annotation) {
-        return fullReflections.getTypesAnnotatedWith(annotation, true);
+        return classIndexByModule.entrySet().stream()
+                .flatMap(entry -> entry.getValue().getTypesAnnotatedWith(annotation.getName())
+                        .stream()
+                        .map(clazzName -> loadClass(classLoaderByModule.get(entry.getKey()), clazzName))
+                ).filter(Objects::nonNull)
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -324,7 +324,13 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
      * as @Inherited
      */
     public Iterable<Class<?>> getTypesAnnotatedWith(Class<? extends Annotation> annotation, Predicate<Class<?>> filter) {
-        return fullReflections.getTypesAnnotatedWith(annotation, true).stream().filter(filter).collect(Collectors.toSet());
+        return classIndexByModule.entrySet().stream()
+                .flatMap(entry -> entry.getValue().getTypesAnnotatedWith(annotation.getName())
+                        .stream()
+                        .map(clazzName -> loadClass(classLoaderByModule.get(entry.getKey()), clazzName))
+                ).filter(Objects::nonNull)
+                .filter(filter)
+                .collect(Collectors.toSet());
     }
 
     @NonNull
@@ -333,9 +339,22 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
         return modules.values().iterator();
     }
 
+    private Class<?> loadClass(ClassLoader classLoader, String clazzName) {
+        try {
+            return classLoader.loadClass(clazzName);
+        } catch (ClassNotFoundException e) {
+            logger.error("Cannot load class", e);
+            return null;
+        } catch (NoClassDefFoundError e) {
+            // Ignore Denied access classes
+            return null;
+        }
+    }
+
 
     @FunctionalInterface
     public interface ClassLoaderSupplier {
         ModuleClassLoader create(Module module, ClassLoader parent, PermissionProvider permissionProvider);
     }
+
 }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleEnvironment.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleEnvironment.java
@@ -43,7 +43,6 @@ import org.terasology.gestalt.module.sandbox.PermissionProvider;
 import org.terasology.gestalt.module.sandbox.PermissionProviderFactory;
 import org.terasology.gestalt.naming.Name;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -305,7 +304,10 @@ public class ModuleEnvironment implements AutoCloseable, Iterable<Module> {
         for (ModuleClassLoader classLoader : managedClassLoaders) {
             try {
                 classLoader.close();
-            } catch (IOException e) {
+                classLoaderByModule.remove(classLoader.getModuleId());
+                classIndexByModule.remove(classLoader.getModuleId());
+                beanContextByModule.remove(classLoader.getModuleId()).close();
+            } catch (Exception e) {
                 logger.error("Failed to close classLoader for module '" + classLoader.getModuleId() + "'", e);
             }
         }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleFactory.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleFactory.java
@@ -36,6 +36,7 @@ import org.terasology.gestalt.module.resources.ArchiveFileSource;
 import org.terasology.gestalt.module.resources.ClasspathFileSource;
 import org.terasology.gestalt.module.resources.DirectoryFileSource;
 
+import javax.inject.Inject;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -68,6 +69,7 @@ public class ModuleFactory {
     private String defaultLibsSubpath;
     private boolean scanningForClasses = true;
 
+    @Inject // TODO use another constructor.
     public ModuleFactory() {
         this(Thread.currentThread().getContextClassLoader());
     }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleMetadataJsonAdapter.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleMetadataJsonAdapter.java
@@ -28,7 +28,6 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
-
 import org.terasology.gestalt.i18n.I18nMap;
 import org.terasology.gestalt.i18n.gson.I18nMapTypeAdapter;
 import org.terasology.gestalt.module.dependencyresolution.DependencyInfo;
@@ -37,6 +36,7 @@ import org.terasology.gestalt.naming.Version;
 import org.terasology.gestalt.naming.gson.NameTypeAdapter;
 import org.terasology.gestalt.naming.gson.VersionTypeAdapter;
 
+import javax.inject.Inject;
 import java.io.Reader;
 import java.io.Writer;
 import java.lang.reflect.Type;
@@ -81,6 +81,7 @@ public class ModuleMetadataJsonAdapter implements ModuleMetadataLoader {
     private final Map<String, Type> extensionMap = Maps.newHashMap();
     private volatile Gson cachedGson;
 
+    @Inject
     public ModuleMetadataJsonAdapter() {
         this.builder = new GsonBuilder()
                 .setPrettyPrinting()

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/ModulePathScanner.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/ModulePathScanner.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.util.Varargs;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -35,10 +36,7 @@ public class ModulePathScanner {
     private static final Logger logger = LoggerFactory.getLogger(ModulePathScanner.class);
     private final ModuleFactory moduleFactory;
 
-    public ModulePathScanner() {
-        this.moduleFactory = new ModuleFactory();
-    }
-
+    @Inject
     public ModulePathScanner(ModuleFactory factory) {
         this.moduleFactory = factory;
     }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleServiceRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleServiceRegistry.java
@@ -5,13 +5,13 @@ import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
 import org.terasology.gestalt.module.sandbox.PermissionProviderFactory;
 
 public class ModuleServiceRegistry extends ServiceRegistry {
-    public ModuleServiceRegistry(Class<? extends PermissionProviderFactory> permissionProviderFactory) {
+    public ModuleServiceRegistry(PermissionProviderFactory permissionProviderFactory) {
         with(ModulePathScanner.class);
         with(ModuleMetadataJsonAdapter.class);
         with(ModulePathScanner.class);
         with(ModuleFactory.class);
         with(TableModuleRegistry.class);
         with(DependencyResolver.class);
-        with(permissionProviderFactory);
+        with(PermissionProviderFactory.class).use(() -> permissionProviderFactory);
     }
 }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleServiceRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleServiceRegistry.java
@@ -1,0 +1,17 @@
+package org.terasology.gestalt.module;
+
+import org.terasology.gestalt.di.ServiceRegistry;
+import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
+import org.terasology.gestalt.module.sandbox.PermissionProviderFactory;
+
+public class ModuleServiceRegistry extends ServiceRegistry {
+    public ModuleServiceRegistry(Class<? extends PermissionProviderFactory> permissionProviderFactory) {
+        with(ModulePathScanner.class);
+        with(ModuleMetadataJsonAdapter.class);
+        with(ModulePathScanner.class);
+        with(ModuleFactory.class);
+        with(TableModuleRegistry.class);
+        with(DependencyResolver.class);
+        with(permissionProviderFactory);
+    }
+}

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/TableModuleRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/TableModuleRegistry.java
@@ -21,12 +21,12 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.Version;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -44,6 +44,11 @@ public class TableModuleRegistry implements ModuleRegistry {
 
     private final Table<Name, Version, Module> modules = HashBasedTable.create();
     private final Map<Name, Module> latestModules = Maps.newHashMap();
+
+    @Inject
+    public TableModuleRegistry() {
+
+    }
 
     @Override
     public boolean add(Module module) {

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/dependencyresolution/DependencyResolver.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/dependencyresolution/DependencyResolver.java
@@ -21,6 +21,7 @@ import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.Version;
 import org.terasology.gestalt.naming.VersionRange;
 
+import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -45,6 +46,7 @@ public class DependencyResolver {
      *
      * @param registry The registry to resolve modules from
      */
+    @Inject
     public DependencyResolver(ModuleRegistry registry) {
         this(registry, OptionalResolutionStrategy.INCLUDE_IF_REQUIRED);
     }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
@@ -100,7 +100,7 @@ public class ClasspathFileSource implements ModuleFileSource {
         }
         String fullpath = buildPathString(filepath);
         if (classLoader.getResource(fullpath) != null) {
-            return Optional.of(new ClasspathSourceFileReference(fullpath.substring(0, fullpath.length() - 1), extractSubpath(basePath, fullpath), classLoader));
+            return Optional.of(new ClasspathSourceFileReference(fullpath, extractSubpath(basePath, fullpath), classLoader));
         } else {
             return Optional.empty();
         }
@@ -119,7 +119,7 @@ public class ClasspathFileSource implements ModuleFileSource {
         }
 
         return candidates
-                .map(file -> new ClasspathSourceFileReference(file.substring(0, file.length() - 1), extractSubpath(basePath, file), classLoader))
+                .map(file -> new ClasspathSourceFileReference(file, extractSubpath(basePath, file), classLoader))
                 .collect(Collectors.toSet());
     }
 

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
@@ -112,7 +112,7 @@ public class ClasspathFileSource implements ModuleFileSource {
         Stream<String> candidates = files
                 .stream()
                 .filter(file -> file.startsWith(fullPath))
-                .filter(file -> file.matches(".+?/[a-zA-Z0-9]+\\.[a-zA-Z0-9]+"));
+                .filter(file -> file.matches(".+?/[a-zA-Z0-9-]+\\.[a-zA-Z-0-9]+"));
 
         if (!recursive) {
             candidates = candidates.filter(file -> !file.substring(fullPath.length()).contains("/"));

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/APIScanner.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/APIScanner.java
@@ -17,9 +17,8 @@
 package org.terasology.gestalt.module.sandbox;
 
 import com.google.common.reflect.Reflection;
-
-import org.reflections.Reflections;
 import org.terasology.context.annotation.API;
+import org.terasology.gestalt.di.index.ClassIndex;
 
 /**
  * Scans a reflections manifest for API annotated classes and packages, registering them with a {@link StandardPermissionProviderFactory}.
@@ -43,26 +42,34 @@ public class APIScanner {
     /**
      * Scans a reflections manifest, adding any class or package marked with the @API annotation into appropriate permission sets. Permission sets will be created if necessary.
      *
-     * @param manifest The reflections manifest to scan
+     * @param classIndex The class index.
      */
-    public void scan(Reflections manifest) {
-        for (Class<?> apiClass : manifest.getTypesAnnotatedWith(API.class, true)) {
-            if (forClassLoader == apiClass.getClassLoader()) {
-                for (String permissionSetId : apiClass.getAnnotation(API.class).permissionSet()) {
-                    PermissionSet permissionSet = permissionProviderFactory.getPermissionSet(permissionSetId);
-                    if (permissionSet == null) {
-                        permissionSet = new PermissionSet();
-                        permissionProviderFactory.addPermissionSet(permissionSetId, permissionSet);
-                    }
-                    if (apiClass.isSynthetic()) {
-                        // This is a package-info
-                        permissionSet.addAPIPackage(Reflection.getPackageName(apiClass));
-                    } else {
-                        permissionSet.addAPIClass(apiClass);
+    public void scan(ClassIndex classIndex) {
+        for (String apiClass : classIndex.getTypesAnnotatedWith(API.class.getName())) {
+            try {
+                Class<?> aClass = forClassLoader.loadClass(apiClass);
+
+                if (aClass != null) {
+                    for (String permissionSetId : aClass.getAnnotation(API.class).permissionSet()) {
+                        PermissionSet permissionSet = permissionProviderFactory.getPermissionSet(permissionSetId);
+                        if (permissionSet == null) {
+                            permissionSet = new PermissionSet();
+                            permissionProviderFactory.addPermissionSet(permissionSetId, permissionSet);
+                        }
+                        if (aClass.isSynthetic()) {
+                            // This is a package-info
+                            permissionSet.addAPIPackage(Reflection.getPackageName(apiClass));
+                        } else {
+                            permissionSet.addAPIClass(aClass);
+                        }
                     }
                 }
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+                // TODO ignore
             }
         }
+
     }
 
 }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/APIScanner.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/APIScanner.java
@@ -17,6 +17,8 @@
 package org.terasology.gestalt.module.sandbox;
 
 import com.google.common.reflect.Reflection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.context.annotation.API;
 import org.terasology.gestalt.di.index.ClassIndex;
 
@@ -26,6 +28,8 @@ import org.terasology.gestalt.di.index.ClassIndex;
  * @author Immortius
  */
 public class APIScanner {
+
+    private static final Logger logger = LoggerFactory.getLogger(APIScanner.class);
 
     private StandardPermissionProviderFactory permissionProviderFactory;
     private ClassLoader forClassLoader;
@@ -45,10 +49,11 @@ public class APIScanner {
      * @param classIndex The class index.
      */
     public void scan(ClassIndex classIndex) {
+        logger.trace("Scan ClassIndex for @API classes");
         for (String apiClass : classIndex.getTypesAnnotatedWith(API.class.getName())) {
             try {
+                logger.trace("T");
                 Class<?> aClass = forClassLoader.loadClass(apiClass);
-
                 if (aClass != null) {
                     for (String permissionSetId : aClass.getAnnotation(API.class).permissionSet()) {
                         PermissionSet permissionSet = permissionProviderFactory.getPermissionSet(permissionSetId);

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/PermitAllPermissionProviderFactory.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/PermitAllPermissionProviderFactory.java
@@ -18,7 +18,6 @@ package org.terasology.gestalt.module.sandbox;
 
 import org.terasology.gestalt.module.Module;
 
-import javax.inject.Inject;
 import java.security.Permission;
 import java.util.function.Predicate;
 
@@ -27,11 +26,6 @@ import java.util.function.Predicate;
  * custom modules are not a factor.
  */
 public class PermitAllPermissionProviderFactory implements PermissionProviderFactory {
-
-    @Inject
-    public PermitAllPermissionProviderFactory() {
-
-    }
 
     @Override
     public PermissionProvider createPermissionProviderFor(Module module, Predicate<Class<?>> classpathModuleClasses) {

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/PermitAllPermissionProviderFactory.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/PermitAllPermissionProviderFactory.java
@@ -18,6 +18,7 @@ package org.terasology.gestalt.module.sandbox;
 
 import org.terasology.gestalt.module.Module;
 
+import javax.inject.Inject;
 import java.security.Permission;
 import java.util.function.Predicate;
 
@@ -26,6 +27,11 @@ import java.util.function.Predicate;
  * custom modules are not a factor.
  */
 public class PermitAllPermissionProviderFactory implements PermissionProviderFactory {
+
+    @Inject
+    public PermitAllPermissionProviderFactory() {
+
+    }
 
     @Override
     public PermissionProvider createPermissionProviderFor(Module module, Predicate<Class<?>> classpathModuleClasses) {

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/StandardPermissionProviderFactory.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/StandardPermissionProviderFactory.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.module.Module;
 
-import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -40,7 +39,6 @@ public class StandardPermissionProviderFactory implements PermissionProviderFact
     private static final Logger logger = LoggerFactory.getLogger(StandardPermissionProviderFactory.class);
     private final Map<String, PermissionSet> permissionSets = Maps.newHashMap();
 
-    @Inject
     public StandardPermissionProviderFactory() {
         permissionSets.put(BASE_PERMISSION_SET, new PermissionSet());
     }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/StandardPermissionProviderFactory.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/StandardPermissionProviderFactory.java
@@ -18,11 +18,11 @@ package org.terasology.gestalt.module.sandbox;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.gestalt.module.Module;
 
+import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -40,6 +40,7 @@ public class StandardPermissionProviderFactory implements PermissionProviderFact
     private static final Logger logger = LoggerFactory.getLogger(StandardPermissionProviderFactory.class);
     private final Map<String, PermissionSet> permissionSets = Maps.newHashMap();
 
+    @Inject
     public StandardPermissionProviderFactory() {
         permissionSets.put(BASE_PERMISSION_SET, new PermissionSet());
     }

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/DependencyResolverTestBase.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/DependencyResolverTestBase.java
@@ -16,9 +16,7 @@
 
 package org.terasology.gestalt.module;
 
-import org.reflections.Configuration;
-import org.reflections.Reflections;
-import org.reflections.util.ConfigurationBuilder;
+import org.terasology.gestalt.di.index.UrlClassIndex;
 import org.terasology.gestalt.module.dependencyresolution.DependencyInfo;
 import org.terasology.gestalt.module.resources.EmptyFileSource;
 import org.terasology.gestalt.naming.Name;
@@ -63,8 +61,7 @@ public class DependencyResolverTestBase {
         ModuleMetadata metadata = new ModuleMetadata();
         metadata.setId(new Name(id));
         metadata.setVersion(new Version(version));
-        Configuration config = new ConfigurationBuilder();
-        Module module = new Module(metadata, new EmptyFileSource(), Collections.emptyList(), new Reflections(config), x -> false);
+        Module module = new Module(metadata, new EmptyFileSource(), Collections.emptyList(), UrlClassIndex.byClassLoader(), x -> false);
         forRegistry.add(module);
         return module;
     }

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/EmbeddedLibraryTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/EmbeddedLibraryTest.java
@@ -17,7 +17,6 @@
 package org.terasology.gestalt.module;
 
 import com.google.common.collect.Sets;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
@@ -47,7 +46,7 @@ public class EmbeddedLibraryTest {
     @Before
     public void setup() {
         registry = new TableModuleRegistry();
-        new ModulePathScanner().scan(registry, Paths.get("test-modules").toFile());
+        new ModulePathScanner(new ModuleFactory()).scan(registry, Paths.get("test-modules").toFile());
 
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("sun.reflect");
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.lang");

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/EmbeddedLibraryTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/EmbeddedLibraryTest.java
@@ -19,6 +19,9 @@ package org.terasology.gestalt.module;
 import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
+import org.module.Test1Scoped;
+import org.module.TestImplementation1;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
 import org.terasology.gestalt.module.sandbox.ModuleSecurityManager;
 import org.terasology.gestalt.module.sandbox.ModuleSecurityPolicy;
@@ -51,6 +54,15 @@ public class EmbeddedLibraryTest {
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("sun.reflect");
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.lang");
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.util");
+
+        // gestalt-di required
+        permissionProviderFactory.getBasePermissionSet().addAPIPackage("org.terasology.context");
+        permissionProviderFactory.getBasePermissionSet().addAPIPackage("javax.inject");
+
+        // Di's tests
+        permissionProviderFactory.getBasePermissionSet().addAPIClass(TestImplementation1.class);
+        permissionProviderFactory.getBasePermissionSet().addAPIClass(Test1Scoped.class);
+
         PermissionSet ioPermissionSet = new PermissionSet();
         ioPermissionSet.addAPIPackage("java.io");
         ioPermissionSet.addAPIPackage("java.nio.file");
@@ -66,7 +78,7 @@ public class EmbeddedLibraryTest {
     @Test
     public void loadedModuleContainsEmbeddedLibraryClasses() {
         DependencyResolver resolver = new DependencyResolver(registry);
-        ModuleEnvironment environment = new ModuleEnvironment(resolver.resolve(new Name("moduleE")).getModules(), permissionProviderFactory);
+        ModuleEnvironment environment = new ModuleEnvironment(new DefaultBeanContext(), resolver.resolve(new Name("moduleE")).getModules(), permissionProviderFactory);
 
         LinkedHashSet<Class<?>> classes = Sets.newLinkedHashSet(environment.getTypesAnnotatedWith(IndexForTest.class));
 

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/PermissiveSandboxTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/PermissiveSandboxTest.java
@@ -44,7 +44,7 @@ public class PermissiveSandboxTest {
     @Before
     public void setup() {
         registry = new TableModuleRegistry();
-        new ModulePathScanner().scan(registry, Paths.get("test-modules").toFile());
+        new ModulePathScanner(new ModuleFactory()).scan(registry, Paths.get("test-modules").toFile());
         StandardPermissionProviderFactory standardPermissionProviderFactory = new StandardPermissionProviderFactory();
 
         standardPermissionProviderFactory.getBasePermissionSet().addAPIPackage("sun.reflect");

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/PermissiveSandboxTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/PermissiveSandboxTest.java
@@ -18,6 +18,7 @@ package org.terasology.gestalt.module;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
 import org.terasology.gestalt.module.sandbox.ModuleSecurityManager;
 import org.terasology.gestalt.module.sandbox.ModuleSecurityPolicy;
@@ -68,7 +69,7 @@ public class PermissiveSandboxTest {
     public void accessToNormalMethod() throws Exception {
         DependencyResolver resolver = new DependencyResolver(registry);
         ModuleEnvironment environment =
-                new ModuleEnvironment(resolver.resolve(new Name("moduleA")).getModules(), permissionProviderFactory);
+                new ModuleEnvironment(new DefaultBeanContext(), resolver.resolve(new Name("moduleA")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleAClass", environment);
         Object instance = type.newInstance();
@@ -80,7 +81,7 @@ public class PermissiveSandboxTest {
     public void deniedAccessToRestrictedClass() throws Exception {
         DependencyResolver resolver = new DependencyResolver(registry);
         ModuleEnvironment environment =
-                new ModuleEnvironment(resolver.resolve(new Name("moduleA")).getModules(), permissionProviderFactory);
+                new ModuleEnvironment(new DefaultBeanContext(), resolver.resolve(new Name("moduleA")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleAClass", environment);
         Object instance = type.newInstance();
@@ -92,7 +93,7 @@ public class PermissiveSandboxTest {
     public void allowedAccessToClassFromRequiredPermissionSet() throws Exception {
         DependencyResolver resolver = new DependencyResolver(registry);
         ModuleEnvironment environment =
-                new ModuleEnvironment(resolver.resolve(new Name("moduleB")).getModules(), permissionProviderFactory);
+                new ModuleEnvironment(new DefaultBeanContext(), resolver.resolve(new Name("moduleB")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleBClass", environment);
         Object instance = type.newInstance();
@@ -104,7 +105,7 @@ public class PermissiveSandboxTest {
     public void deniedAccessToClassPermittedToParent() throws Exception {
         DependencyResolver resolver = new DependencyResolver(registry);
         ModuleEnvironment environment =
-                new ModuleEnvironment(resolver.resolve(new Name("moduleC")).getModules(), permissionProviderFactory);
+                new ModuleEnvironment(new DefaultBeanContext(), resolver.resolve(new Name("moduleC")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleCClass", environment);
         Object instance = type.newInstance();

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/SandboxTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/SandboxTest.java
@@ -52,7 +52,7 @@ public class SandboxTest {
     @Before
     public void setup() {
         registry = new TableModuleRegistry();
-        new ModulePathScanner().scan(registry, Paths.get("test-modules").toFile());
+        new ModulePathScanner(new ModuleFactory()).scan(registry, Paths.get("test-modules").toFile());
 
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.lang");
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.util");

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/SandboxTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/SandboxTest.java
@@ -17,13 +17,9 @@
 package org.terasology.gestalt.module;
 
 import com.google.common.collect.Lists;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
+import org.terasology.gestalt.di.index.UrlClassIndex;
 import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
 import org.terasology.gestalt.module.resources.EmptyFileSource;
 import org.terasology.gestalt.module.sandbox.ModuleSecurityManager;
@@ -142,8 +138,7 @@ public class SandboxTest {
         metadata.setId(new Name("PackageModule"));
         metadata.setVersion(Version.DEFAULT);
 
-        Reflections reflections = new Reflections(new ConfigurationBuilder().forPackages("org.terasology.gestalt.module.packageModule").addClassLoader(ClasspathHelper.contextClassLoader()).addScanners(new SubTypesScanner()));
-        Module module = new Module(metadata, new EmptyFileSource(), Collections.emptyList(), reflections, x -> com.google.common.reflect.Reflection.getPackageName(x).startsWith("org.terasology.gestalt.module.packageModule"));
+        Module module = new Module(metadata, new EmptyFileSource(), Collections.emptyList(), UrlClassIndex.byClassLoaderPrefix("org.terasology.gestalt.module.packageModule"), x -> com.google.common.reflect.Reflection.getPackageName(x).startsWith("org.terasology.gestalt.module.packageModule"));
         List<Module> modules = Lists.newArrayList(module);
         modules.addAll(resolver.resolve(new Name("moduleC")).getModules());
         ModuleEnvironment environment = new ModuleEnvironment(modules, permissionProviderFactory);

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/SandboxTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/SandboxTest.java
@@ -19,6 +19,10 @@ package org.terasology.gestalt.module;
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
+import org.module.Test1Scoped;
+import org.module.TestImplementation1;
+import org.terasology.gestalt.di.BeanContext;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.di.index.UrlClassIndex;
 import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
 import org.terasology.gestalt.module.resources.EmptyFileSource;
@@ -46,16 +50,24 @@ import static org.junit.Assert.assertTrue;
  */
 public class SandboxTest {
 
-    private ModuleRegistry registry;
+    private DependencyResolver resolver;
     private StandardPermissionProviderFactory permissionProviderFactory = new StandardPermissionProviderFactory();
+    private BeanContext root;
 
     @Before
     public void setup() {
-        registry = new TableModuleRegistry();
-        new ModulePathScanner(new ModuleFactory()).scan(registry, Paths.get("test-modules").toFile());
-
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.lang");
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.util");
+
+
+        // gestalt-di required
+        permissionProviderFactory.getBasePermissionSet().addAPIPackage("org.terasology.context");
+        permissionProviderFactory.getBasePermissionSet().addAPIPackage("javax.inject");
+
+        // Di's tests
+        permissionProviderFactory.getBasePermissionSet().addAPIClass(TestImplementation1.class);
+        permissionProviderFactory.getBasePermissionSet().addAPIClass(Test1Scoped.class);
+
         PermissionSet ioPermissionSet = new PermissionSet();
         ioPermissionSet.addAPIPackage("java.io");
         ioPermissionSet.addAPIPackage("java.nio.file");
@@ -67,13 +79,16 @@ public class SandboxTest {
 
         Policy.setPolicy(new ModuleSecurityPolicy());
         System.setSecurityManager(new ModuleSecurityManager());
+
+        root = new DefaultBeanContext(new ModuleServiceRegistry(permissionProviderFactory));
+        root.getBean(ModulePathScanner.class).scan(root.getBean(ModuleRegistry.class), Paths.get("test-modules").toFile());
+        resolver = root.getBean(DependencyResolver.class);
     }
 
     // Ensure a normal method using globally allowed classes works
     @Test
     public void accessToNormalMethod() throws Exception {
-        DependencyResolver resolver = new DependencyResolver(registry);
-        ModuleEnvironment environment = new ModuleEnvironment(resolver.resolve(new Name("moduleA")).getModules(), permissionProviderFactory);
+        ModuleEnvironment environment = new ModuleEnvironment(root, resolver.resolve(new Name("moduleA")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleAClass", environment);
         Object instance = type.newInstance();
@@ -83,8 +98,7 @@ public class SandboxTest {
     // Ensure access to disallowed classes fails
     @Test(expected = InvocationTargetException.class)
     public void deniedAccessToRestrictedClassInMethod() throws Exception {
-        DependencyResolver resolver = new DependencyResolver(registry);
-        ModuleEnvironment environment = new ModuleEnvironment(resolver.resolve(new Name("moduleB")).getModules(), permissionProviderFactory);
+        ModuleEnvironment environment = new ModuleEnvironment(root, resolver.resolve(new Name("moduleB")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleBClass", environment);
         Object instance = type.newInstance();
@@ -93,16 +107,14 @@ public class SandboxTest {
 
     @Test(expected = ClassNotFoundException.class)
     public void deniedAccessToClassImplementingRestrictedInterface() throws Exception {
-        DependencyResolver resolver = new DependencyResolver(registry);
-        ModuleEnvironment environment = new ModuleEnvironment(resolver.resolve(new Name("moduleD")).getModules(), permissionProviderFactory);
+        ModuleEnvironment environment = new ModuleEnvironment(root, resolver.resolve(new Name("moduleD")).getModules(), permissionProviderFactory);
 
         findClass("ModuleDRestrictedClass", environment);
     }
 
     @Test
     public void allowedAccessToClassImplementingPermissionSetInterface() throws Exception {
-        DependencyResolver resolver = new DependencyResolver(registry);
-        ModuleEnvironment environment = new ModuleEnvironment(resolver.resolve(new Name("moduleB")).getModules(), permissionProviderFactory);
+        ModuleEnvironment environment = new ModuleEnvironment(root, resolver.resolve(new Name("moduleB")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleBPermittedClass", environment);
         assertNotNull(type);
@@ -112,8 +124,7 @@ public class SandboxTest {
     // Ensures access to additionally required permission sets works (both classes and permissions)
     @Test
     public void allowedAccessToClassFromRequiredPermissionSet() throws Exception {
-        DependencyResolver resolver = new DependencyResolver(registry);
-        ModuleEnvironment environment = new ModuleEnvironment(resolver.resolve(new Name("moduleB")).getModules(), permissionProviderFactory);
+        ModuleEnvironment environment = new ModuleEnvironment(root, resolver.resolve(new Name("moduleB")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleBClass", environment);
         Object instance = type.newInstance();
@@ -123,8 +134,7 @@ public class SandboxTest {
     // Ensure that a module doesn't gain accesses required by the parent but not by itself
     @Test(expected = InvocationTargetException.class)
     public void deniedAccessToClassPermittedToParent() throws Exception {
-        DependencyResolver resolver = new DependencyResolver(registry);
-        ModuleEnvironment environment = new ModuleEnvironment(resolver.resolve(new Name("moduleC")).getModules(), permissionProviderFactory);
+        ModuleEnvironment environment = new ModuleEnvironment(root, resolver.resolve(new Name("moduleC")).getModules(), permissionProviderFactory);
 
         Class<?> type = findClass("ModuleCClass", environment);
         Object instance = type.newInstance();
@@ -133,7 +143,6 @@ public class SandboxTest {
 
     @Test
     public void allowedAccessToPackageModuleClassViaModuleClassloader() throws Exception {
-        DependencyResolver resolver = new DependencyResolver(registry);
         ModuleMetadata metadata = new ModuleMetadata();
         metadata.setId(new Name("PackageModule"));
         metadata.setVersion(Version.DEFAULT);
@@ -141,7 +150,7 @@ public class SandboxTest {
         Module module = new Module(metadata, new EmptyFileSource(), Collections.emptyList(), UrlClassIndex.byClassLoaderPrefix("org.terasology.gestalt.module.packageModule"), x -> com.google.common.reflect.Reflection.getPackageName(x).startsWith("org.terasology.gestalt.module.packageModule"));
         List<Module> modules = Lists.newArrayList(module);
         modules.addAll(resolver.resolve(new Name("moduleC")).getModules());
-        ModuleEnvironment environment = new ModuleEnvironment(modules, permissionProviderFactory);
+        ModuleEnvironment environment = new ModuleEnvironment(root, modules, permissionProviderFactory);
         Object result = findClass("StandaloneClass", environment).newInstance();
         assertNotNull(result);
     }

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/TableModuleRegistryTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/TableModuleRegistryTest.java
@@ -17,8 +17,7 @@
 package org.terasology.gestalt.module;
 
 import org.junit.Test;
-import org.reflections.Reflections;
-import org.reflections.util.ConfigurationBuilder;
+import org.terasology.gestalt.di.index.UrlClassIndex;
 import org.terasology.gestalt.module.resources.EmptyFileSource;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.gestalt.naming.Version;
@@ -78,6 +77,6 @@ public class TableModuleRegistryTest {
         ModuleMetadata metadata = new ModuleMetadata();
         metadata.setId(name);
         metadata.setVersion(version);
-        return new Module(metadata, new EmptyFileSource(), Collections.emptyList(), new Reflections(new ConfigurationBuilder()), x -> false);
+        return new Module(metadata, new EmptyFileSource(), Collections.emptyList(), UrlClassIndex.byClassLoader(), x -> false);
     }
 }

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/di/BeanContextInModuleTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/di/BeanContextInModuleTest.java
@@ -1,0 +1,47 @@
+package org.terasology.gestalt.module.di;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.module.TestImplementation1;
+import org.terasology.gestalt.di.BeanContext;
+import org.terasology.gestalt.di.DefaultBeanContext;
+import org.terasology.gestalt.module.ModuleEnvironment;
+import org.terasology.gestalt.module.ModulePathScanner;
+import org.terasology.gestalt.module.ModuleRegistry;
+import org.terasology.gestalt.module.ModuleServiceRegistry;
+import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
+import org.terasology.gestalt.module.sandbox.PermissionProviderFactory;
+import org.terasology.gestalt.module.sandbox.PermitAllPermissionProviderFactory;
+import org.terasology.gestalt.naming.Name;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+public class BeanContextInModuleTest {
+
+    private ModuleEnvironment environment;
+
+    @Before
+    public void setup() {
+        BeanContext root = new DefaultBeanContext(new ModuleServiceRegistry(PermitAllPermissionProviderFactory.class));
+
+        ModulePathScanner scanner = root.getBean(ModulePathScanner.class);
+        ModuleRegistry registry = root.getBean(ModuleRegistry.class);
+        scanner.scan(registry, Paths.get("test-modules").toFile());
+
+        environment = new ModuleEnvironment(root,
+                root.getBean(DependencyResolver.class).resolve(new Name("moduleB")).getModules(),
+                root.getBean(PermissionProviderFactory.class));
+    }
+
+    @Test
+    public void lookupByInterface() {
+        List<? extends TestImplementation1> list = environment.getBeans(TestImplementation1.class);
+        Assert.assertFalse(list.isEmpty());
+        Assert.assertEquals(
+                new String[]{"org.module.b.DepByInterface"},
+                list.stream().map(o -> o.getClass().getName()).toArray(String[]::new)
+        );
+    }
+}

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/di/BeanContextInModuleTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/di/BeanContextInModuleTest.java
@@ -12,7 +12,7 @@ import org.terasology.gestalt.module.ModuleRegistry;
 import org.terasology.gestalt.module.ModuleServiceRegistry;
 import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
 import org.terasology.gestalt.module.sandbox.PermissionProviderFactory;
-import org.terasology.gestalt.module.sandbox.PermitAllPermissionProviderFactory;
+import org.terasology.gestalt.module.sandbox.StandardPermissionProviderFactory;
 import org.terasology.gestalt.naming.Name;
 
 import java.nio.file.Paths;
@@ -24,7 +24,7 @@ public class BeanContextInModuleTest {
 
     @Before
     public void setup() {
-        BeanContext root = new DefaultBeanContext(new ModuleServiceRegistry(PermitAllPermissionProviderFactory.class));
+        BeanContext root = new DefaultBeanContext(new ModuleServiceRegistry(new StandardPermissionProviderFactory()));
 
         ModulePathScanner scanner = root.getBean(ModulePathScanner.class);
         ModuleRegistry registry = root.getBean(ModuleRegistry.class);
@@ -36,7 +36,7 @@ public class BeanContextInModuleTest {
     }
 
     @Test
-    public void lookupByInterface() {
+    public void findByInterface() {
         List<? extends TestImplementation1> list = environment.getBeans(TestImplementation1.class);
         Assert.assertFalse(list.isEmpty());
         Assert.assertEquals(

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/di/BeanContextInModuleTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/di/BeanContextInModuleTest.java
@@ -12,7 +12,7 @@ import org.terasology.gestalt.module.ModuleRegistry;
 import org.terasology.gestalt.module.ModuleServiceRegistry;
 import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
 import org.terasology.gestalt.module.sandbox.PermissionProviderFactory;
-import org.terasology.gestalt.module.sandbox.StandardPermissionProviderFactory;
+import org.terasology.gestalt.module.sandbox.PermitAllPermissionProviderFactory;
 import org.terasology.gestalt.naming.Name;
 
 import java.nio.file.Paths;
@@ -24,7 +24,7 @@ public class BeanContextInModuleTest {
 
     @Before
     public void setup() {
-        BeanContext root = new DefaultBeanContext(new ModuleServiceRegistry(new StandardPermissionProviderFactory()));
+        BeanContext root = new DefaultBeanContext(new ModuleServiceRegistry(new PermitAllPermissionProviderFactory()));
 
         ModulePathScanner scanner = root.getBean(ModulePathScanner.class);
         ModuleRegistry registry = root.getBean(ModuleRegistry.class);

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/resources/ClasspathFileSourceTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/resources/ClasspathFileSourceTest.java
@@ -17,8 +17,6 @@
 package org.terasology.gestalt.module.resources;
 
 import org.junit.BeforeClass;
-import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
 
 public class ClasspathFileSourceTest extends BaseFileSourceTest {
 
@@ -26,10 +24,7 @@ public class ClasspathFileSourceTest extends BaseFileSourceTest {
 
     @BeforeClass
     public static void setup() {
-        ResourcesScanner resourcesScanner = new ResourcesScanner();
-        resourcesScanner.setResultFilter(x -> false);
-        Reflections manifest = new Reflections("content", resourcesScanner);
-        source = new ClasspathFileSource(manifest, "content");
+        source = new ClasspathFileSource("content");
     }
 
     @Override

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/APIScannerTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/APIScannerTest.java
@@ -17,10 +17,7 @@
 package org.terasology.gestalt.module.sandbox;
 
 import org.junit.Test;
-import org.reflections.Reflections;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
+import org.terasology.gestalt.di.index.UrlClassIndex;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -39,10 +36,8 @@ public class APIScannerTest {
         PermissionSet permSet = new PermissionSet();
         when(permissionProviderFactory.getPermissionSet(any(String.class))).thenReturn(permSet);
 
-        ConfigurationBuilder config = new ConfigurationBuilder().addClassLoader(ClasspathHelper.contextClassLoader()).addUrls(ClasspathHelper.forClassLoader()).addScanners(new TypeAnnotationsScanner());
-        Reflections reflections = new Reflections(config);
 
-        new APIScanner(permissionProviderFactory).scan(reflections);
+        new APIScanner(permissionProviderFactory).scan(UrlClassIndex.byClassLoader());
         assertTrue(permSet.isPermitted(APIClass.class));
         assertFalse(permSet.isPermitted(NonAPIClassInheritingAPIClass.class));
     }

--- a/testpack/testpack-api/src/main/java/org/terasology/test/api/IndexForTest.java
+++ b/testpack/testpack-api/src/main/java/org/terasology/test/api/IndexForTest.java
@@ -16,6 +16,8 @@
 
 package org.terasology.test.api;
 
+import org.terasology.context.annotation.Index;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -28,5 +30,6 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Index
 public @interface IndexForTest {
 }


### PR DESCRIPTION
* removes `Reflections`
* `gestalt-di` provide indexes
* Provides 2 new AnnotationProcessor:
  * ResourceProcessor - creates index processor for fast lookup resources(assets etc) (required custom setup)
  * SubtypeProcessor - creates class index by annotation and subtypes
* Using Annotation processing for Class and Resource indexes. ( works same for idea and gradle, except detect changes at resources from IDEA)
* ResourceIndex using for ClassPathFileSource ( Directory and archive file sources is not changed)
* ClassIndex(SubtypesProcessor) using for `ModuleEnvironment#getSubtypes` and `ApiScanner` only. (compactability reason, part of classes will getting via `BeanContext`)
* Adapt API scanner( hehe packages with `@API` marks all classes within instead separate package handling)
* Integrate `BeanContext` to `ModuleEnvironment`
 