### PR TITLE
Gestalt DI: Fixed building and running on Windows

### DIFF
--- a/gestalt-android-testbed/build.gradle
+++ b/gestalt-android-testbed/build.gradle
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-import com.google.common.base.Predicate
-import org.reflections.Reflections
-import org.reflections.scanners.ResourcesScanner
-import org.reflections.scanners.SubTypesScanner
-import org.reflections.scanners.TypeAnnotationsScanner
-import org.reflections.serializers.JsonSerializer
-import org.reflections.util.ConfigurationBuilder
-
-import java.util.regex.Pattern
-
 apply plugin: 'com.android.application'
 apply plugin: 'project-report'
 
@@ -41,23 +31,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    packagingOptions {
+        merge 'META-INF/annotations/*'
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-    applicationVariants.all {
-        variant ->
-            def t = task("reflect${variant.name.capitalize()}") {
-                description = "Generates reflections manifest for variant ${variant.name}"
-
-                doLast {
-                    reflectPackage("org.terasology.gestalt.android.testbed.packageModuleA", variant)
-                    reflectPackage("org.terasology.gestalt.android.testbed.packageModuleB", variant)
-                }
-            }
-            variant.assembleProvider.get().dependsOn(t)
     }
     lintOptions {
         abortOnError false
@@ -78,32 +59,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-}
 
-def reflectPackage(packageName, variant) {
-    def resourcesPath = variant.sourceSets.find { it.name == 'main' }.resources.srcDirs
-    def classPath = files { variant.javaCompileProvider.get().destinationDir }
-    URL[] scanUrls = classPath.collect { it.toURI().toURL() } + resourcesPath.collect {
-        it.toURI().toURL()
-    }
-    URL[] classLoaderUrls = scanUrls + variant.javaCompileProvider.get().classpath.collect {
-        it.toURI().toURL()
-    } + [new File(android.sdkDirectory, "platforms/" + android.compileSdkVersion + "/android.jar").toURI().toURL()]
-
-    ClassLoader classLoader = new URLClassLoader(classLoaderUrls, getClass().getClassLoader())
-    org.reflections.Configuration config = new ConfigurationBuilder()
-    config.addClassLoader(classLoader)
-    config.setUrls(scanUrls)
-    config.filterInputsBy(new Predicate<String>() {
-        @Override
-        boolean apply(@javax.annotation.Nullable String s) {
-            return packageName.isEmpty() || s.startsWith(packageName + ".")
-        }
-    })
-
-    config.addScanners(new ResourcesScanner(), new SubTypesScanner(false), new TypeAnnotationsScanner().filterResultsBy())
-    Reflections reflections = new Reflections(config)
-    JsonSerializer serializer = new JsonSerializer()
-    def outPath = variant.javaCompileProvider.get().destinationDir.toString() + "/" + packageName.replaceAll(Pattern.quote("."), "/") + "/manifest.json"
-    serializer.save(reflections, outPath)
+    annotationProcessor project(":gestalt-inject-java")
 }

--- a/gestalt-android-testbed/src/main/java/org/terasology/gestalt/android/testbed/GestaltTestActivity.java
+++ b/gestalt-android-testbed/src/main/java/org/terasology/gestalt/android/testbed/GestaltTestActivity.java
@@ -35,11 +35,13 @@ import org.terasology.gestalt.android.testbed.assettypes.Text;
 import org.terasology.gestalt.android.testbed.assettypes.TextData;
 import org.terasology.gestalt.android.testbed.assettypes.TextFactory;
 import org.terasology.gestalt.android.testbed.assettypes.TextFileFormat;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.ModuleFactory;
 import org.terasology.gestalt.module.ModuleMetadata;
 import org.terasology.gestalt.module.ModulePathScanner;
+import org.terasology.gestalt.module.ModuleServiceRegistry;
 import org.terasology.gestalt.module.TableModuleRegistry;
 import org.terasology.gestalt.module.resources.FileReference;
 import org.terasology.gestalt.module.sandbox.StandardPermissionProviderFactory;
@@ -93,7 +95,7 @@ public class GestaltTestActivity extends AppCompatActivity {
         StandardPermissionProviderFactory permissionProviderFactory = new StandardPermissionProviderFactory();
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.lang");
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("org.terasology.test.api");
-        ModuleEnvironment environment = new ModuleEnvironment(moduleRegistry, new WarnOnlyProviderFactory(permissionProviderFactory), (module, parent, permissionProvider) -> AndroidModuleClassLoader.create(module, parent, permissionProvider, getCodeCacheDir()));
+        ModuleEnvironment environment = new ModuleEnvironment(new DefaultBeanContext(new ModuleServiceRegistry(permissionProviderFactory)), moduleRegistry, new WarnOnlyProviderFactory(permissionProviderFactory), (module, parent, permissionProvider) -> AndroidModuleClassLoader.create(module, parent, permissionProvider, getCodeCacheDir()));
 
 
         displayText.append("-== Module Content ==-\n\n");

--- a/gestalt-android/build.gradle
+++ b/gestalt-android/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     }
     implementation project(':gestalt-util')
     implementation "org.slf4j:slf4j-api:$slf4j_version"
+    implementation "com.google.guava:guava:$guava_version"
 
     implementation 'com.android.support:appcompat-v7:28.0.0'
     testImplementation "junit:junit:$junit_version"

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/AnnotationTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/AnnotationTypeWriter.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class AnnotationTypeWriter {
-    private static final String META_INF = "META-INF" + File.separator + "annotations";
+    private static final String META_INF = "META-INF/annotations";
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
@@ -30,7 +30,7 @@ public class AnnotationTypeWriter {
 
     public void finish() throws IOException {
         for (Map.Entry<String, HashSet<String>> pair : results.entrySet()) {
-            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + File.separator + pair.getKey());
+            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + "/" + pair.getKey());
             try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
                 for (String clazz : pair.getValue()) {
                     writer.write(clazz);

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 
 @SupportedOptions("resource")
 public class ResourceProcessor extends AbstractProcessor {
-    private static final String FILE = "META-INF" + File.separator + "resources";
+    private static final String FILE = "META-INF/resources";
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @SupportedOptions("resource")
@@ -40,6 +41,9 @@ public class ResourceProcessor extends AbstractProcessor {
                             List<String> files = Files.walk(root)
                                     .map(root::relativize)
                                     .map(Objects::toString)
+                                    // Regularise paths to always use "/" as a path separator,
+                                    // as ClassLoader.getResources() always uses "/" in its returned paths.
+                                    .map(filePath -> String.join("/", filePath.split(Pattern.quote(File.separator))))
                                     .filter(str -> !str.endsWith(".class"))
                                     .filter(str -> !str.isEmpty())
                                     .collect(Collectors.toList());

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ServiceTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ServiceTypeWriter.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class ServiceTypeWriter {
-    private static final String META_INF = "META-INF" + File.separator + "services";
+    private static final String META_INF = "META-INF/services";
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
@@ -30,7 +30,7 @@ public class ServiceTypeWriter {
 
     public void finish() throws IOException {
         for (Map.Entry<String, HashSet<String>> pair : results.entrySet()) {
-            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + File.separator + pair.getKey());
+            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + "/" + pair.getKey());
             try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
                 for (String clazz : pair.getValue()) {
                     writer.write(clazz);

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/SubtypesTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/SubtypesTypeWriter.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class SubtypesTypeWriter {
-    private static final String META_INF = "META-INF" + File.separator + "subtypes";
+    private static final String META_INF = "META-INF/subtypes";
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
@@ -30,7 +30,7 @@ public class SubtypesTypeWriter {
 
     public void finish() throws IOException {
         for (Map.Entry<String, HashSet<String>> pair : results.entrySet()) {
-            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + File.separator + pair.getKey());
+            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + "/" + pair.getKey());
             try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
                 for (String clazz : pair.getValue()) {
                     writer.write(clazz);


### PR DESCRIPTION
With these changes, running `gradlew build` on Windows should succeed and everything should compile correctly.
> `Filer.createResource` doesn't actually take a filesystem path. "A valid relative name must match the "path-rootless" rule of RFC 3986, section 3.3. " (https://docs.oracle.com/javase/8/docs/api/javax/annotation/processing/Filer.html). On Windows, `File.separator` is `\`, which is not a valid path character in RFC 3986 (https://www.ietf.org/rfc/rfc3986.txt). So, basically, you can replace the `File.separator` with `"/"` to make it work.

This also fixes the compilation (but not execution) of `gestalt-android-testbed` and removes any reflections tasks from it, as they are not used anymore.