### PR TITLE
Gestalt DI: Fixed running on android

### DIFF
--- a/gestalt-android-testbed/build.gradle
+++ b/gestalt-android-testbed/build.gradle
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-import com.google.common.base.Predicate
-import org.reflections.Reflections
-import org.reflections.scanners.ResourcesScanner
-import org.reflections.scanners.SubTypesScanner
-import org.reflections.scanners.TypeAnnotationsScanner
-import org.reflections.serializers.JsonSerializer
-import org.reflections.util.ConfigurationBuilder
-
-import java.util.regex.Pattern
-
 apply plugin: 'com.android.application'
 apply plugin: 'project-report'
 
@@ -41,23 +31,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    packagingOptions {
+        merge 'META-INF/annotations/*'
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-    applicationVariants.all {
-        variant ->
-            def t = task("reflect${variant.name.capitalize()}") {
-                description = "Generates reflections manifest for variant ${variant.name}"
-
-                doLast {
-                    reflectPackage("org.terasology.gestalt.android.testbed.packageModuleA", variant)
-                    reflectPackage("org.terasology.gestalt.android.testbed.packageModuleB", variant)
-                }
-            }
-            variant.assembleProvider.get().dependsOn(t)
     }
     lintOptions {
         abortOnError false
@@ -78,32 +59,6 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-}
 
-def reflectPackage(packageName, variant) {
-    def resourcesPath = variant.sourceSets.find { it.name == 'main' }.resources.srcDirs
-    def classPath = files { variant.javaCompileProvider.get().destinationDir }
-    URL[] scanUrls = classPath.collect { it.toURI().toURL() } + resourcesPath.collect {
-        it.toURI().toURL()
-    }
-    URL[] classLoaderUrls = scanUrls + variant.javaCompileProvider.get().classpath.collect {
-        it.toURI().toURL()
-    } + [new File(android.sdkDirectory, "platforms/" + android.compileSdkVersion + "/android.jar").toURI().toURL()]
-
-    ClassLoader classLoader = new URLClassLoader(classLoaderUrls, getClass().getClassLoader())
-    org.reflections.Configuration config = new ConfigurationBuilder()
-    config.addClassLoader(classLoader)
-    config.setUrls(scanUrls)
-    config.filterInputsBy(new Predicate<String>() {
-        @Override
-        boolean apply(@javax.annotation.Nullable String s) {
-            return packageName.isEmpty() || s.startsWith(packageName + ".")
-        }
-    })
-
-    config.addScanners(new ResourcesScanner(), new SubTypesScanner(false), new TypeAnnotationsScanner().filterResultsBy())
-    Reflections reflections = new Reflections(config)
-    JsonSerializer serializer = new JsonSerializer()
-    def outPath = variant.javaCompileProvider.get().destinationDir.toString() + "/" + packageName.replaceAll(Pattern.quote("."), "/") + "/manifest.json"
-    serializer.save(reflections, outPath)
+    annotationProcessor project(":gestalt-inject-java")
 }

--- a/gestalt-android-testbed/build.gradle
+++ b/gestalt-android-testbed/build.gradle
@@ -62,3 +62,14 @@ dependencies {
 
     annotationProcessor project(":gestalt-inject-java")
 }
+
+// Android projects don't provide direct access to compileJava but this seems to work.
+// https://stackoverflow.com/a/42297051
+gradle.projectsEvaluated {
+    tasks.withType(JavaCompile) {
+        // Adds Resources as parameter for AnnotationProcessor (gather ResourceIndex,
+        // also add resource as input for compilejava, for re-gathering ResourceIndex, when resource was changed.
+        inputs.files android.sourceSets.main.resources.srcDirs
+        options.compilerArgs = ["-Aresource=${android.sourceSets.main.resources.srcDirs.join(File.pathSeparator)}"]
+    }
+}

--- a/gestalt-android-testbed/src/main/java/org/terasology/gestalt/android/testbed/GestaltTestActivity.java
+++ b/gestalt-android-testbed/src/main/java/org/terasology/gestalt/android/testbed/GestaltTestActivity.java
@@ -35,11 +35,13 @@ import org.terasology.gestalt.android.testbed.assettypes.Text;
 import org.terasology.gestalt.android.testbed.assettypes.TextData;
 import org.terasology.gestalt.android.testbed.assettypes.TextFactory;
 import org.terasology.gestalt.android.testbed.assettypes.TextFileFormat;
+import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.ModuleFactory;
 import org.terasology.gestalt.module.ModuleMetadata;
 import org.terasology.gestalt.module.ModulePathScanner;
+import org.terasology.gestalt.module.ModuleServiceRegistry;
 import org.terasology.gestalt.module.TableModuleRegistry;
 import org.terasology.gestalt.module.resources.FileReference;
 import org.terasology.gestalt.module.sandbox.StandardPermissionProviderFactory;
@@ -93,7 +95,7 @@ public class GestaltTestActivity extends AppCompatActivity {
         StandardPermissionProviderFactory permissionProviderFactory = new StandardPermissionProviderFactory();
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("java.lang");
         permissionProviderFactory.getBasePermissionSet().addAPIPackage("org.terasology.test.api");
-        ModuleEnvironment environment = new ModuleEnvironment(moduleRegistry, new WarnOnlyProviderFactory(permissionProviderFactory), (module, parent, permissionProvider) -> AndroidModuleClassLoader.create(module, parent, permissionProvider, getCodeCacheDir()));
+        ModuleEnvironment environment = new ModuleEnvironment(new DefaultBeanContext(new ModuleServiceRegistry(permissionProviderFactory)), moduleRegistry, new WarnOnlyProviderFactory(permissionProviderFactory), (module, parent, permissionProvider) -> AndroidModuleClassLoader.create(module, parent, permissionProvider, getCodeCacheDir()));
 
 
         displayText.append("-== Module Content ==-\n\n");

--- a/gestalt-android-testbed/src/main/res/layout/activity_gestalt_test.xml
+++ b/gestalt-android-testbed/src/main/res/layout/activity_gestalt_test.xml
@@ -21,14 +21,20 @@
     android:layout_height="match_parent"
     tools:context=".GestaltTestActivity">
 
-    <TextView
-        android:id="@+id/textDisplay"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+        <TextView
+                android:id="@+id/textDisplay"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:text="Hello World!"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+    </ScrollView>
 
 </android.support.constraint.ConstraintLayout>

--- a/gestalt-android/build.gradle
+++ b/gestalt-android/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     }
     implementation project(':gestalt-util')
     implementation "org.slf4j:slf4j-api:$slf4j_version"
+    implementation "com.google.guava:guava:$guava_version"
 
     implementation 'com.android.support:appcompat-v7:28.0.0'
     testImplementation "junit:junit:$junit_version"

--- a/gestalt-android/src/main/java/org/terasology/gestalt/android/AndroidModuleClassLoader.java
+++ b/gestalt-android/src/main/java/org/terasology/gestalt/android/AndroidModuleClassLoader.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.context.FindResourcesClassLoader;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.sandbox.JavaModuleClassLoader;
 import org.terasology.gestalt.module.sandbox.ModuleClassLoader;
@@ -28,7 +29,9 @@ import org.terasology.gestalt.module.sandbox.PermissionProvider;
 import org.terasology.gestalt.naming.Name;
 
 import java.io.File;
+import java.net.URL;
 import java.security.AccessController;
+import java.util.Enumeration;
 import java.util.List;
 
 import dalvik.system.DexClassLoader;
@@ -36,7 +39,7 @@ import dalvik.system.DexClassLoader;
 /**
  * A module class loader built on top of DexClassLoader, to support loading code under Android.
  */
-public class AndroidModuleClassLoader extends DexClassLoader implements ModuleClassLoader {
+public class AndroidModuleClassLoader extends DexClassLoader implements ModuleClassLoader, FindResourcesClassLoader {
 
     private static final Logger logger = LoggerFactory.getLogger(JavaModuleClassLoader.class);
     private static final Joiner FILE_JOINER = Joiner.on(File.pathSeparatorChar);
@@ -92,6 +95,11 @@ public class AndroidModuleClassLoader extends DexClassLoader implements ModuleCl
     @Override
     public PermissionProvider getPermissionProvider() {
         return permissionProvider;
+    }
+
+    @Override
+    public Enumeration<URL> findResources(String name) {
+        return super.findResources(name);
     }
 
     /**

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/AnnotationTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/AnnotationTypeWriter.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class AnnotationTypeWriter {
-    private static final String META_INF = "META-INF" + File.separator + "annotations";
+    private static final String META_INF = "META-INF/annotations";
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
@@ -30,7 +30,7 @@ public class AnnotationTypeWriter {
 
     public void finish() throws IOException {
         for (Map.Entry<String, HashSet<String>> pair : results.entrySet()) {
-            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + File.separator + pair.getKey());
+            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + "/" + pair.getKey());
             try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
                 for (String clazz : pair.getValue()) {
                     writer.write(clazz);

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
@@ -15,7 +15,10 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Queue;
@@ -110,6 +113,10 @@ public class ClassIndexProcessor extends AbstractProcessor {
         try {
             annotationTypeWriter.finish();
             subtypesTypeWriter.finish();
+            FileObject file = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "META-INF/gestalt-indexes-present");
+            Writer writer = file.openWriter();
+            writer.write("true");
+            writer.close();
         } catch (IOException e) {
             processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Cannot write indexes: " + e.getMessage());
         }

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 
 @SupportedOptions("resource")
 public class ResourceProcessor extends AbstractProcessor {
-    private static final String FILE = "META-INF" + File.separator + "resources";
+    private static final String FILE = "META-INF/resources";
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ResourceProcessor.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @SupportedOptions("resource")
@@ -40,6 +41,9 @@ public class ResourceProcessor extends AbstractProcessor {
                             List<String> files = Files.walk(root)
                                     .map(root::relativize)
                                     .map(Objects::toString)
+                                    // Regularise paths to always use "/" as a path separator,
+                                    // as ClassLoader.getResources() always uses "/" in its returned paths.
+                                    .map(filePath -> String.join("/", filePath.split(Pattern.quote(File.separator))))
                                     .filter(str -> !str.endsWith(".class"))
                                     .filter(str -> !str.isEmpty())
                                     .collect(Collectors.toList());

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ServiceTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ServiceTypeWriter.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class ServiceTypeWriter {
-    private static final String META_INF = "META-INF" + File.separator + "services";
+    private static final String META_INF = "META-INF/services";
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
@@ -30,7 +30,7 @@ public class ServiceTypeWriter {
 
     public void finish() throws IOException {
         for (Map.Entry<String, HashSet<String>> pair : results.entrySet()) {
-            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + File.separator + pair.getKey());
+            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + "/" + pair.getKey());
             try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
                 for (String clazz : pair.getValue()) {
                     writer.write(clazz);

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/SubtypesTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/SubtypesTypeWriter.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class SubtypesTypeWriter {
-    private static final String META_INF = "META-INF" + File.separator + "subtypes";
+    private static final String META_INF = "META-INF/subtypes";
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
@@ -30,7 +30,7 @@ public class SubtypesTypeWriter {
 
     public void finish() throws IOException {
         for (Map.Entry<String, HashSet<String>> pair : results.entrySet()) {
-            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + File.separator + pair.getKey());
+            FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", META_INF + "/" + pair.getKey());
             try (BufferedWriter writer = new BufferedWriter(fileObject.openWriter())) {
                 for (String clazz : pair.getValue()) {
                     writer.write(clazz);

--- a/gestalt-inject/src/main/java/org/terasology/context/FindResourcesClassLoader.java
+++ b/gestalt-inject/src/main/java/org/terasology/context/FindResourcesClassLoader.java
@@ -1,0 +1,8 @@
+package org.terasology.context;
+
+import java.net.URL;
+import java.util.Enumeration;
+
+public interface FindResourcesClassLoader {
+    Enumeration<URL> findResources(String name);
+}

--- a/gestalt-inject/src/main/java/org/terasology/context/SoftServiceLoader.java
+++ b/gestalt-inject/src/main/java/org/terasology/context/SoftServiceLoader.java
@@ -35,8 +35,8 @@ public class SoftServiceLoader<S> implements Iterable<S> {
     }
 
     public SoftServiceLoader(Class<S> target, ClassLoader classLoader, boolean loadsFromParent) {
-        Preconditions.checkArgument(loadsFromParent || classLoader instanceof URLClassLoader,
-                "loadsFromParent == false implemented for UrlClassLoader only");
+        Preconditions.checkArgument(loadsFromParent || classLoader instanceof URLClassLoader || classLoader instanceof FindResourcesClassLoader,
+                "loadsFromParent == false implemented for UrlClassLoader or FindResourcesClassLoader only");
         this.target = target;
         this.classLoader = classLoader;
         this.loadsFromParent = loadsFromParent;
@@ -53,6 +53,8 @@ public class SoftServiceLoader<S> implements Iterable<S> {
             Enumeration<URL> urls;
             if (!loadsFromParent && classLoader instanceof URLClassLoader) {
                 urls = ((URLClassLoader) classLoader).findResources(META_INF_SERVICES + '/' + target.getName());
+            } else if (!loadsFromParent && classLoader instanceof FindResourcesClassLoader) {
+                urls = ((FindResourcesClassLoader) classLoader).findResources(META_INF_SERVICES + '/' + target.getName());
             } else {
                 urls = classLoader.getResources(META_INF_SERVICES + '/' + target.getName());
             }

--- a/testpack/testpack-api/src/main/java/org/terasology/test/api/ApiInterface.java
+++ b/testpack/testpack-api/src/main/java/org/terasology/test/api/ApiInterface.java
@@ -16,9 +16,12 @@
 
 package org.terasology.test.api;
 
+import org.terasology.context.annotation.IndexInherited;
+
 /**
  * @author Immortius
  */
+@IndexInherited
 public interface ApiInterface {
 
     String apiMethod();


### PR DESCRIPTION
### Description
These fixes allow the `gestalt-android-testbed` project to run successfully. A major work-around has been added to `UrlClassIndex` though to allow the apk `META-INF` directory to be found. The text displayed in the `gestalt-android-testbed` app is now wrapped in a `ScrollView`, so that it is not cut-off when it exceeeds the current height of the screen.

These changes depend on #93.

### Known Issues
- On android, checking for the presence of the `META-INF` directory or any of its sub-directories with `ClassLoader.getResource` appears to always return false. Checking directly for the presence of files in the `META-INF` directory or any of its sub-directories still works though. I do not know why this is although it may have something to do with the way that jar/apk files are handled (see [here](https://cs.android.com/android/platform/superproject/+/master:libcore/ojluni/src/main/java/sun/misc/JarIndex.java;l=244-260?q=lang:java%20comment:%22META-INF%22)). I have worked around this `UrlClassIndex` for now.
- On android, `URLClassLoader` is not used, so I created a seperate interface, `FindResourcesClassLoader`, for custom class loaders that expose that particular method. I checked the source code for android's `DexPathLoader` and it does appear to implement it correctly [here](https://cs.android.com/android/platform/superproject/+/master:libcore/dalvik/src/main/java/dalvik/system/BaseDexClassLoader.java;l=257-277;drc=master) and [here](https://cs.android.com/android/platform/superproject/+/master:libcore/dalvik/src/main/java/dalvik/system/DexPathList.java;l=569-580;drc=master;bpv=1;bpt=1), so I exposed the protected method as public in `AndroidModuleClassLoader`.

### Screenshots
![Screenshot_1616786430](https://user-images.githubusercontent.com/24301287/112719133-242a1e00-8eef-11eb-879a-765d92517e27.png)