### PR TITLE
test: fix tests under java 11

### DIFF
--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/APIScannerTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/APIScannerTest.java
@@ -9,6 +9,9 @@ import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 
+import java.net.URL;
+import java.util.Collection;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
@@ -21,12 +24,18 @@ import static org.mockito.Mockito.when;
 public class APIScannerTest {
 
     @Test
-    public void test() throws Exception {
+    public void testAnnotatedClassIsPermitted() {
         StandardPermissionProviderFactory permissionProviderFactory = mock(StandardPermissionProviderFactory.class);
         PermissionSet permSet = new PermissionSet();
         when(permissionProviderFactory.getPermissionSet(any(String.class))).thenReturn(permSet);
 
-        ConfigurationBuilder config = new ConfigurationBuilder().addClassLoader(ClasspathHelper.contextClassLoader()).addUrls(ClasspathHelper.forClassLoader()).addScanners(new TypeAnnotationsScanner());
+        Collection<URL> urls = ClasspathHelper.forJavaClassPath();
+        assertFalse(urls.isEmpty(), "Tried to construct test reflections with no URLs.");
+
+        ConfigurationBuilder config =
+                new ConfigurationBuilder()
+                        .addUrls(urls)
+                        .addScanners(new TypeAnnotationsScanner());
         Reflections reflections = new Reflections(config);
 
         new APIScanner(permissionProviderFactory).scan(reflections);

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/APIScannerTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/APIScannerTest.java
@@ -8,6 +8,7 @@ import org.reflections.Reflections;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
+import org.terasology.gestalt.module.sandbox.apipackage.ClassInApiPackage;
 
 import java.net.URL;
 import java.util.Collection;
@@ -41,5 +42,6 @@ public class APIScannerTest {
         new APIScanner(permissionProviderFactory).scan(reflections);
         assertTrue(permSet.isPermitted(APIClass.class));
         assertFalse(permSet.isPermitted(NonAPIClassInheritingAPIClass.class));
+        assertTrue(permSet.isPermitted(ClassInApiPackage.class));
     }
 }

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/APIScannerTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/APIScannerTest.java
@@ -15,7 +15,7 @@ import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/apipackage/ClassInApiPackage.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/apipackage/ClassInApiPackage.java
@@ -1,0 +1,8 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.gestalt.module.sandbox.apipackage;
+
+/** This class is not annotated, but the package-info is. */
+public class ClassInApiPackage {
+}

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/apipackage/package-info.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/sandbox/apipackage/package-info.java
@@ -1,0 +1,7 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+@API
+package org.terasology.gestalt.module.sandbox.apipackage;
+
+import org.terasology.gestalt.module.sandbox.API;


### PR DESCRIPTION
Fixes tests that fail under java 11 for ClassLoader.getURLs reasons.

Or fixes one test, anyway. I thought I saw other test failures earlier, but now running `test` in the gestalt project gets 321 passing and no skips or failures, so :shrug: 

Depends on #97 