### PR TITLE
fix: allow VersionRange to target a snapshot version

### DIFF
--- a/gestalt-module/src/test/java/org/terasology/gestalt/naming/VersionRangeTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/naming/VersionRangeTest.java
@@ -63,4 +63,13 @@ public class VersionRangeTest {
     public void higherSnapshotOutOfRange() {
         assertFalse(range.contains(new Version("2.3.4-SNAPSHOT")));
     }
+
+    @Test
+    public void canMatchMajorSnapshot() {
+        Version majorSnapshot = new Version("2.0.0-SNAPSHOT");
+        Version majorRelease = new Version("2.0.0");
+
+        VersionRange snapshotRange = new VersionRange(majorSnapshot, majorRelease);
+        assertTrue(snapshotRange.contains(majorSnapshot));
+    }
 }


### PR DESCRIPTION
It's also possible that this is not-a-bug and the real bug is that DependencyInfo.versionRange that is so narrow? #101 

based on #98 