### PR TITLE
feat: use Semver compatibility for dependency info

### DIFF
--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/dependencyresolution/DependencyInfo.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/dependencyresolution/DependencyInfo.java
@@ -1,26 +1,15 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.gestalt.module.dependencyresolution;
 
 import org.terasology.gestalt.naming.Name;
+import org.terasology.gestalt.naming.SemverExpression;
 import org.terasology.gestalt.naming.Version;
 import org.terasology.gestalt.naming.VersionRange;
 
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Describes a dependency on a module. Dependencies apply to a range of versions - anything from the min version (inclusive) to the max version (exclusive) are supported.
@@ -124,6 +113,21 @@ public class DependencyInfo {
      */
     public VersionRange versionRange() {
         return new VersionRange(getMinVersion(), getMaxVersion());
+    }
+
+    public Predicate<Version> versionPredicate() {
+        if (maxVersion != null) {
+            return versionRange();
+        } else {
+            String source;
+            if (minVersion.isSnapshot()) {
+                // semver doesn't like snapshots in caret ranges?
+                source = minVersion + " | ^" + minVersion.getNextPatchVersion();
+            } else {
+                source = "^" + minVersion;
+            }
+            return new SemverExpression(source);
+        }
     }
 
     @Override

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/dependencyresolution/DependencyResolver.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/dependencyresolution/DependencyResolver.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.gestalt.module.dependencyresolution;
 
@@ -25,6 +12,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * Dependency Resolver determines a working set of modules for a given set of desired modules. Where multiple versions are compatible, they are resolved in favour of the
@@ -86,7 +74,7 @@ public class DependencyResolver {
      * Prepares and performs the process of resolving dependencies.
      */
     public class ResolutionBuilder {
-        private final Map<Name, Optional<VersionRange>> validVersions = new HashMap<>();
+        private final Map<Name, Optional<Predicate<Version>>> validVersions = new HashMap<>();
 
         /**
          * Adds a module to the set of requirements.

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/SemverExpression.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/SemverExpression.java
@@ -1,0 +1,32 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.gestalt.naming;
+
+import com.github.zafarkhaja.semver.expr.ExpressionParser;
+import com.google.common.base.MoreObjects;
+
+import java.util.function.Predicate;
+
+public class SemverExpression implements Predicate<Version> {
+
+    private final Predicate<com.github.zafarkhaja.semver.Version> expression;
+    private final String source;
+
+    public SemverExpression(String source) {
+        this.source = source;
+        this.expression = ExpressionParser.newInstance().parse(source);
+    }
+
+    @Override
+    public boolean test(Version version) {
+        return expression.test(version.semver);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .addValue(source)
+                .toString();
+    }
+}

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.gestalt.naming;
 
 import com.github.zafarkhaja.semver.ParseException;
@@ -32,7 +19,7 @@ public final class Version implements Comparable<Version> {
 
     private static final String SNAPSHOT = "SNAPSHOT";
 
-    private com.github.zafarkhaja.semver.Version semver;
+    com.github.zafarkhaja.semver.Version semver;
 
     /**
      * Constructs a version with the given values

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/VersionRange.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/VersionRange.java
@@ -1,31 +1,19 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.gestalt.naming;
 
 import com.google.common.base.Preconditions;
 
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * A range of versions from a lower-bound (inclusive) to an upper-bound (exclusive).
  *
  * @author Immortius
  */
-public class VersionRange {
+public class VersionRange implements Predicate<Version> {
     private final Version lowerBound;
     private final Version upperBound;
 
@@ -57,6 +45,11 @@ public class VersionRange {
      */
     public boolean contains(Version version) {
         return version.compareTo(lowerBound.getSnapshot()) >= 0 && version.compareTo(upperBound.getSnapshot()) < 0;
+    }
+
+    @Override
+    public boolean test(Version version) {
+        return contains(version);
     }
 
     @Override


### PR DESCRIPTION
Version 7 introduced the use of the Semver library (#80) for some functions of version handling. It changed the behavior of `getNextVersion` methods (as mentioned in its PR), and that left DependencyInfo returning an unsatisfiable version range when a module's `minVersion` targets a snapshot. (#100) https://github.com/MovingBlocks/gestalt/blob/a51ba072f2e7c8e084ddf0b530d73bbb713ae2a3/gestalt-module/src/main/java/org/terasology/gestalt/module/dependencyresolution/DependencyInfo.java#L84-L89

Rather than try to re-implement the semantics of satisfying semantic versioning in the DependencyInfo and VersionRange classes, I propose using more of the Semver library's methods for this.

This PR is a step in that direction. It keeps the VersionRange class intact to preserve compatibility, but if a DependencyInfo was defined with _only_ a minimal version, instead of building a gestalt.VersionRange for it, we compile a Semver expression that will determine what matches.

**Dependencies:** #98. If that is not merged yet, you can review using this diff: https://github.com/MovingBlocks/gestalt/compare/v7/test/java11...v7/feat/semverComparison

## Questions for Review

- [x] Is the caret expression the right one?
- [ ] Is it worth keeping the existing VersionRange class at all, or should we convert entirely?
  - If we convert, be mindful of [VersionRangeTest](https://github.com/MovingBlocks/gestalt/blob/a51ba072f2e7c8e084ddf0b530d73bbb713ae2a3/gestalt-module/src/test/java/org/terasology/gestalt/naming/VersionRangeTest.java). lowerSnapshotInRange and higherSnapshotOutOfRange are the ones that are easy to miss. 
  - I only found _one_ place in Terasology that directly uses VersionRange, and it's easy to update.
- [ ] Instead of building an expression out of `minVersion`, should we allow module metadata to define its own expression?
  - We would need to use the Maven-style expressions in that case in order for compile-time dependency resolution to still work.
 