### PR TITLE
ci: add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,19 +6,27 @@ pipeline {
         stage('Build') {
             steps {
                 sh './gradlew --info --console=plain --parallel assemble compileTest'
-                recordIssues enabledForFailure: true, tools: [java()]
+            }
+            post {
+                always {
+                    recordIssues enabledForFailure: true, tools: [java()]
+                }
             }
         }
         stage('Analytics') {
             steps {
-                sh './gradlew --info --console=plain --parallel javadoc check'
-                junit testResults: '**/build/test-results/test/*.xml'
-                recordIssues tools: [
-                  javaDoc(),
-                  taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
-                ]
-                //Note: Javadoc archiver only works for one directory :-(
-                javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false
+                sh './gradlew --info --console=plain --parallel --continue javadoc check'
+            }
+            post {
+                always {
+                    junit testResults: '**/build/test-results/test/*.xml'
+                    recordIssues tools: [
+                      javaDoc(),
+                      taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
+                    ]
+                    //Note: Javadoc archiver only works for one directory :-(
+                    javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false
+                }
             }
         }
         stage('Publish') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,14 +15,16 @@ pipeline {
         }
         stage('Analytics') {
             steps {
-                sh './gradlew --info --console=plain --parallel --continue javadoc check'
+                // `test` seems flaky when run with --parallel, so separate it from other checks
+                sh './gradlew --info --console=plain --continue test'
+                sh './gradlew --info --console=plain --parallel --continue javadoc check --exclude-task test'
             }
             post {
                 always {
                     junit testResults: '**/build/test-results/test/*.xml'
                     recordIssues tools: [
                       javaDoc(),
-                      taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
+                      taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO, FIXME', highTags: 'ASAP')
                     ]
                     //Note: Javadoc archiver only works for one directory :-(
                     javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,38 @@
+pipeline {
+    agent {
+        label "java8"
+    }
+    stages {
+        stage('Build') {
+            steps {
+                sh './gradlew --info --console=plain --parallel assemble compileTest'
+                recordIssues enabledForFailure: true, tools: [java()]
+            }
+        }
+        stage('Analytics') {
+            steps {
+                sh './gradlew --info --console=plain --parallel javadoc check'
+                junit testResults: '**/build/test-results/test/*.xml'
+                recordIssues tools: [
+                  javaDoc(),
+                  taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
+                ]
+                //Note: Javadoc archiver only works for one directory :-(
+                javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false
+            }
+        }
+        stage('Publish') {
+            when {
+                anyOf {
+                    branch 'master'
+                    branch pattern: "release/v\\d+.x", comparator: "REGEXP"
+                }
+            }
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {
+                    sh './gradlew --info --console=plain -Dorg.gradle.internal.publish.checksums.insecure=true publish -PmavenUser=${artifactoryUser} -PmavenPass=${artifactoryPass}'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Based on the release/v5.x branch with a few tweaks.

The build and test stages run okay. The publish stage doesn't publish PR branches, which is good. I guess we'll see if it publishes a snapshot once it is merged?

Differences from #95:
- this targets v7, not develop
- this includes _only_ Jenkinsfile, not other build changes
- the Jenkinsfile has some things ordered differently and runs `gradlew --parallel` in some places, but it is overall compatible. It runs the same gradle tasks and uses the same conditions for when to publish something.