### PR TITLE
ci: build with java 11? [spike]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label "java8"
+        label "java11"
     }
     stages {
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,28 @@
 pipeline {
-    agent {
-        label "java11"
-    }
+    agent none
+    stages {
+        stage("Validate") {
+            matrix {
+                axes {
+                    axis {
+                        name 'JAVA_VERSION'
+                        values 'java8', 'neo-java'
+                    }
+                }
+                agent {
+                    label env.JAVA_VERSION
+                }
     stages {
         stage('Build') {
             steps {
+                sh './gradlew tasks # make sure gradle-wrapper has installed'
+                sh "( ./gradlew --version ; ./gradlew projects buildEnvironment ) | tee build-environment-${JAVA_VERSION}.log"
                 sh './gradlew --info --console=plain --parallel assemble compileTest'
             }
             post {
                 always {
-                    recordIssues enabledForFailure: true, tools: [java()]
+                    recordIssues enabledForFailure: true, tools: [java(id:"java-$JAVA_VERSION", name:"Compilation $JAVA_VERSION")]
+                    archiveArtifacts artifacts: "build-environment-${JAVA_VERSION}.log"
                 }
             }
         }
@@ -23,8 +36,8 @@ pipeline {
                 always {
                     junit testResults: '**/build/test-results/test/*.xml'
                     recordIssues tools: [
-                      javaDoc(),
-                      taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO, FIXME', highTags: 'ASAP')
+                      javaDoc(id:"javaDoc-$JAVA_VERSION", name: "JavaDoc $JAVA_VERSION"),
+                      taskScanner(id:"tasks-$JAVA_VERSION", name: "Tasks $JAVA_VERSION", includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO, FIXME', highTags: 'ASAP')
                     ]
                     //Note: Javadoc archiver only works for one directory :-(
                     javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false
@@ -33,6 +46,7 @@ pipeline {
         }
         stage('Publish') {
             when {
+                expression { env.JAVA_VERSION == 'java8' }
                 anyOf {
                     branch 'master'
                     branch pattern: "release/v\\d+.x", comparator: "REGEXP"
@@ -42,6 +56,10 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {
                     sh './gradlew --info --console=plain -Dorg.gradle.internal.publish.checksums.insecure=true publish -PmavenUser=${artifactoryUser} -PmavenPass=${artifactoryPass}'
                 }
+            }
+        }
+    }
+                
             }
         }
     }


### PR DESCRIPTION
Experimenting to see how we could keep building with whatever lowest-common-denominator JDK we need, but also run the test suite under a newer JDK.