### PR TITLE
Release v5.1.6 and minor logistics tweaks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label "light-java"
+        label "lib && light && java8"
     }
     stages {
         stage('Build') {
@@ -16,7 +16,7 @@ pipeline {
         stage('Publish') {
             when {
                 anyOf {
-                    branch 'master'
+                    branch 'develop'
                     branch pattern: "release/v\\d+.x", comparator: "REGEXP"
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,5 @@
 buildscript {
     repositories {
-        // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-        jcenter()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.1.6-SNAPSHOT
+version=5.1.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,13 @@
-version=5.1.6
+version=5.1.6-SNAPSHOT
+
+# Alternative resolution repo to use - this can be used to ignore "live" artifacts and only accept experimental ones.
+# alternativeResolutionRepo=http://artifactory.terasology.org/artifactory/virtual-nanoware-and-remote
+
+# Where to publish artifacts, if not to the default snapshot/release repos
+# Publishing a snapshot to a release-only repo will get an intended but quirky HTTP 409 Conflict error as of Nov 2014
+#publishRepo=nanoware-snapshot-local
+
+# Credentials for publishing to Artifactory. Consider setting in ~/.gradle/gradle.properties
+# REMEMBER TO NOT CHECK IN ACTUAL CREDENTIAL FROM HERE!
+#mavenUser=
+#mavenPass=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.1.6-SNAPSHOT
+version=5.1.6
 
 # Alternative resolution repo to use - this can be used to ignore "live" artifacts and only accept experimental ones.
 # alternativeResolutionRepo=http://artifactory.terasology.org/artifactory/virtual-nanoware-and-remote

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -54,11 +54,6 @@ check.dependsOn rootProject.extractAnalyticsConfig
 
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {
-    // For development so you can publish binaries locally and have them grabbed from there
-    mavenLocal()
-
-    // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-    jcenter()
     mavenCentral()
 
     // Terasology Artifactory instance for libs not readily available elsewhere plus our own libs


### PR DESCRIPTION
Other than the minor non-functional changes in this PR I _believe_ this would also finally be a release for https://github.com/MovingBlocks/gestalt/commit/f92e9cfd2bb257330eb6bdaf7d82d84d1d34a963 by @keturn from some time ago. TS engine hasn't been able to use that yet but if still relevant (maybe not with v7 support on the horizon) then with this released it should be able to.

Tested both locally and via http://jenkins.terasology.io/teraorg/job/Nanoware/job/Gestalt/job/release%252Fv5.x/ - although "tested" insofar as it builds, haven't tried to actually _use_ it with anything.