### PR TITLE
Release/v7.x logistics updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.war
 *.ear
 /gestalt-module/test-modules/*
+/gestalt-es-perf/test-modules/*
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,19 +6,27 @@ pipeline {
         stage('Build') {
             steps {
                 sh './gradlew --info --console=plain --parallel assemble compileTest'
-                recordIssues enabledForFailure: true, tools: [java()]
+            }
+            post {
+                always {
+                    recordIssues enabledForFailure: true, tools: [java()]
+                }
             }
         }
         stage('Analytics') {
             steps {
-                sh './gradlew --info --console=plain --parallel javadoc check'
-                junit testResults: '**/build/test-results/test/*.xml'
-                recordIssues tools: [
-                  javaDoc(),
-                  taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
-                ]
-                //Note: Javadoc archiver only works for one directory :-(
-                javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false
+                sh './gradlew --info --console=plain --parallel --continue javadoc check'
+            }
+            post {
+                always {
+                    junit testResults: '**/build/test-results/test/*.xml'
+                    recordIssues tools: [
+                      javaDoc(),
+                      taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
+                    ]
+                    //Note: Javadoc archiver only works for one directory :-(
+                    javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false
+                }
             }
         }
         stage('Publish') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,14 +15,16 @@ pipeline {
         }
         stage('Analytics') {
             steps {
-                sh './gradlew --info --console=plain --parallel --continue javadoc check'
+                // `test` seems flaky when run with --parallel, so separate it from other checks
+                sh './gradlew --info --console=plain --continue test'
+                sh './gradlew --info --console=plain --parallel --continue javadoc check --exclude-task test'
             }
             post {
                 always {
                     junit testResults: '**/build/test-results/test/*.xml'
                     recordIssues tools: [
                       javaDoc(),
-                      taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
+                      taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO, FIXME', highTags: 'ASAP')
                     ]
                     //Note: Javadoc archiver only works for one directory :-(
                     javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,38 @@
+pipeline {
+    agent {
+        label "java8"
+    }
+    stages {
+        stage('Build') {
+            steps {
+                sh './gradlew --info --console=plain --parallel assemble compileTest'
+                recordIssues enabledForFailure: true, tools: [java()]
+            }
+        }
+        stage('Analytics') {
+            steps {
+                sh './gradlew --info --console=plain --parallel javadoc check'
+                junit testResults: '**/build/test-results/test/*.xml'
+                recordIssues tools: [
+                  javaDoc(),
+                  taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle,**/*.kts', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
+                ]
+                //Note: Javadoc archiver only works for one directory :-(
+                javadoc javadocDir: 'gestalt-entity-system/build/docs/javadoc', keepAll: false
+            }
+        }
+        stage('Publish') {
+            when {
+                anyOf {
+                    branch 'master'
+                    branch pattern: "release/v\\d+.x", comparator: "REGEXP"
+                }
+            }
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {
+                    sh './gradlew --info --console=plain -Dorg.gradle.internal.publish.checksums.insecure=true publish -PmavenUser=${artifactoryUser} -PmavenPass=${artifactoryPass}'
+                }
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
         stage('Publish') {
             when {
                 anyOf {
-                    branch 'master'
+                    branch 'develop'
                     branch pattern: "release/v\\d+.x", comparator: "REGEXP"
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,5 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
 buildscript {
     repositories {
         google()
@@ -26,39 +18,51 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'org.terasology:reflections:0.9.12-MB'
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'org.terasology:reflections:0.9.12-MB' // This goes away in v8
     }
-    ext {
-        // Android version support
-        android_annotation_version = "28.0.0"
+}
 
-        // Standard Utility
-        guava_version = "27.0.1-android"
-        slf4j_version = "1.7.25"
-        gson_version = "2.8.5"
-        jcip_annotation_version = "1.0"
+ext {
+    // Android version support
+    android_annotation_version = "28.0.0"
 
-        // Testing
-        junit_version = "4.13.2"
-        jupiter_version = "5.7.1"
-        logback_version = "1.2.3"
-        mockito_version = "3.7.7"
-    }
+    // Standard Utility
+    guava_version = "27.0.1-android"
+    slf4j_version = "1.7.25"
+    gson_version = "2.8.5"
+    jcip_annotation_version = "1.0"
+
+    // Testing
+    junit_version = "4.13.2"
+    jupiter_version = "5.7.1"
+    logback_version = "1.2.3"
+    mockito_version = "3.7.7"
 }
 
 allprojects {
     repositories {
         google()
         mavenCentral()
-        // org.jetbrains.trove4j:trove4j
-        gradlePluginPortal()
+
+        // Terasology Artifactory instance for libs not readily available elsewhere plus our own libs
         maven {
-            name = "Terasology Artifactory"
-            url = "http://artifactory.terasology.org/artifactory/libs-release-local"
-            allowInsecureProtocol = true  // 😱
+            def repoViaEnv = System.getenv()["RESOLUTION_REPO"]
+            if (rootProject.hasProperty("alternativeResolutionRepo")) {
+                // If the user supplies an alternative repo via gradle.properties then use that
+                name "from alternativeResolutionRepo property"
+                url alternativeResolutionRepo
+            } else if (repoViaEnv != null && repoViaEnv != "") {
+                name "from \$RESOLUTION_REPO"
+                url = repoViaEnv
+            } else {
+                // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
+                name "Terasology Artifactory"
+                url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
+                allowInsecureProtocol true  // 😱
+            }
         }
+
+        // SemVer lib
         maven {
             url 'https://heisluft.de/maven'
         }
@@ -71,5 +75,3 @@ description = 'A set of libraries providing core capabilities for games and game
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-
-

--- a/gestalt-android-testbed/build.gradle
+++ b/gestalt-android-testbed/build.gradle
@@ -1,19 +1,5 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 import com.google.common.base.Predicate
 import org.reflections.Reflections
 import org.reflections.scanners.ResourcesScanner

--- a/gestalt-android/build.gradle
+++ b/gestalt-android/build.gradle
@@ -1,6 +1,5 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
@@ -70,13 +69,42 @@ project.afterEvaluate {
     publishing {
         repositories {
             maven {
-                credentials {
-                    username project.gestaltMavenRepoUsername
-                    password project.gestaltMavenRepoPassword
+                name = 'TerasologyOrg'
+                allowInsecureProtocol true // 😱 - no https on our Artifactory yet
+
+                if (rootProject.hasProperty("publishRepo")) {
+                    // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
+                    url = "http://artifactory.terasology.org/artifactory/$publishRepo"
+
+                    logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
+                } else {
+                    // Support override from the environment to use a different target publish org
+                    String deducedPublishRepo = System.getenv()["PUBLISH_ORG"]
+                    if (deducedPublishRepo == null || deducedPublishRepo == "") {
+                        // If not then default
+                        deducedPublishRepo = "libs"
+                    }
+
+                    // Base final publish repo on whether we're building a snapshot or a release
+                    if (project.version.endsWith('SNAPSHOT')) {
+                        deducedPublishRepo += "-snapshot-local"
+                    } else {
+                        deducedPublishRepo += "-release-local"
+                    }
+
+                    logger.info("The final deduced publish repo is {}", deducedPublishRepo)
+                    url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
                 }
-                name 'TerasologyTestRepo'
-                allowInsecureProtocol = true  // 😱
-                url project.version.endsWith('SNAPSHOT') ? project.snapshotPublishRepo : project.releasePublishRepo
+
+                if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {
+                    credentials {
+                        username = "$mavenUser"
+                        password = "$mavenPass"
+                    }
+                    authentication {
+                        basic(BasicAuthentication)
+                    }
+                }
             }
         }
         publications {

--- a/gestalt-asset-core/build.gradle
+++ b/gestalt-asset-core/build.gradle
@@ -1,15 +1,6 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/common.gradle"
 
 // Primary dependencies definition
 dependencies {
@@ -33,48 +24,6 @@ dependencies {
 
 description = 'Provides support for assets - binary resources that can be loaded from modules or procedurally generated at runtime.'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 tasks.named("test", Test) {
     useJUnitPlatform()
-}
-
-/***
- * Publishing
- ***/
-
-task sourceJar(type: Jar, dependsOn: classes) {
-    classifier 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-publishing {
-    repositories {
-        maven {
-            credentials {
-                username project.gestaltMavenRepoUsername
-                password project.gestaltMavenRepoPassword
-            }
-            name 'TerasologyTestRepo'
-            allowInsecureProtocol = true  // 😱
-            url project.version.endsWith('SNAPSHOT') ? project.snapshotPublishRepo : project.releasePublishRepo
-        }
-    }
-    publications {
-        mavenAssetCore(MavenPublication) {
-            artifactId = project.name
-            version = project.version
-
-            from components.java
-
-            artifact sourceJar
-            artifact javadocJar
-        }
-    }
 }

--- a/gestalt-entity-system/build.gradle
+++ b/gestalt-entity-system/build.gradle
@@ -1,15 +1,6 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/common.gradle"
 
 // Primary dependencies definition
 dependencies {
@@ -34,61 +25,9 @@ dependencies {
     testImplementation("org.mockito:mockito-junit-jupiter:$mockito_version")
 }
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
-    }
-}
-
 description = 'A threadsafe entity system implementation. ' +
         'An entity system is a component based data model.'
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 tasks.named("test", Test) {
     useJUnitPlatform()
 }
-
-/***
- * Publishing
- ***/
-
-task sourceJar(type: Jar, dependsOn: classes) {
-    classifier 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-publishing {
-    repositories {
-        maven {
-            credentials {
-                username project.gestaltMavenRepoUsername
-                password project.gestaltMavenRepoPassword
-            }
-            name 'TerasologyTestRepo'
-            allowInsecureProtocol = true  // 😱
-            url project.version.endsWith('SNAPSHOT') ? project.snapshotPublishRepo : project.releasePublishRepo
-        }
-    }
-    publications {
-        mavenEs(MavenPublication) {
-            artifactId = project.name
-            version = project.version
-
-            from components.java
-
-            artifact sourceJar
-            artifact javadocJar
-        }
-    }
-}
-

--- a/gestalt-es-perf/build.gradle
+++ b/gestalt-es-perf/build.gradle
@@ -1,15 +1,6 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/common.gradle"
 
 // Primary dependencies definition
 dependencies {
@@ -35,9 +26,6 @@ dependencies {
 
 description = 'High performance access methods to replace the use of reflections in gestalt-entity-system. Can be used in Java 7+ and Android API 26+.'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 /***
  * Testpack inclusion
  */
@@ -55,44 +43,3 @@ tasks.named("test", Test) {
     dependsOn(gatherModules)
     useJUnitPlatform()
 }
-
-/***
- * Publishing
- ***/
-
-task sourceJar(type: Jar, dependsOn: classes) {
-    classifier 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-publishing {
-    repositories {
-        maven {
-            credentials {
-                username project.gestaltMavenRepoUsername
-                password project.gestaltMavenRepoPassword
-            }
-            name 'TerasologyTestRepo'
-            allowInsecureProtocol = true  // 😱
-            url project.version.endsWith('SNAPSHOT') ? project.snapshotPublishRepo : project.releasePublishRepo
-        }
-    }
-    publications {
-        mavenEsPerf(MavenPublication) {
-            artifactId = project.name
-            version = project.version
-
-            from components.java
-
-            artifact sourceJar
-            artifact javadocJar
-        }
-    }
-}
-
-

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -1,21 +1,6 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
-
-repositories {
-    maven {
-        url = 'https://heisluft.de/maven/'
-    }
-}
+apply from: "$rootDir/gradle/common.gradle"
 
 // Primary dependencies definition
 dependencies {
@@ -43,9 +28,6 @@ dependencies {
 
 // Library and distribution config
 description = 'Provides support for modules - java libraries that can be activated at runtime and run in a sandboxed environment'
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 task gatherJarModules(dependsOn: [':testpack:moduleA:jar', ':testpack:moduleB:jar', ':testpack:moduleC:jar', ':testpack:moduleD:jar'], type: Copy)
 task createModuleE(dependsOn: [':gestalt-module:copyModuleEInfo', ':gestalt-module:copyModuleELibs'])
@@ -79,43 +61,3 @@ tasks.named("test", Test) {
     dependsOn(gatherModules)
     useJUnitPlatform()
 }
-
-/***
- * Publishing
- ***/
-
-task sourceJar(type: Jar, dependsOn: classes) {
-    classifier 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-publishing {
-    repositories {
-        maven {
-            credentials {
-                username project.gestaltMavenRepoUsername
-                password project.gestaltMavenRepoPassword
-            }
-            name 'TerasologyTestRepo'
-            allowInsecureProtocol = true  // 😱
-            url project.version.endsWith('SNAPSHOT') ? project.snapshotPublishRepo : project.releasePublishRepo
-        }
-    }
-    publications {
-        mavenModule(MavenPublication) {
-            artifactId = project.name
-            version = project.version
-
-            from components.java
-
-            artifact sourceJar
-            artifact javadocJar
-        }
-    }
-}
-

--- a/gestalt-serialization/build.gradle
+++ b/gestalt-serialization/build.gradle
@@ -1,19 +1,5 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 apply plugin: 'java-library'
 
 dependencies {

--- a/gestalt-util/build.gradle
+++ b/gestalt-util/build.gradle
@@ -1,15 +1,6 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/common.gradle"
 
 // Primary dependencies definition
 dependencies {
@@ -33,49 +24,6 @@ dependencies {
 // Library and distribution config
 description = 'Common utility classes'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 tasks.named("test", Test) {
     useJUnitPlatform()
 }
-
-/***
- * Publishing
- ***/
-
-task sourceJar(type: Jar, dependsOn: classes) {
-    classifier 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-publishing {
-    repositories {
-        maven {
-            credentials {
-                username project.gestaltMavenRepoUsername
-                password project.gestaltMavenRepoPassword
-            }
-            name 'TerasologyTestRepo'
-            allowInsecureProtocol = true  // 😱
-            url project.version.endsWith('SNAPSHOT') ? project.snapshotPublishRepo : project.releasePublishRepo
-        }
-    }
-    publications {
-        mavenUtil(MavenPublication) {
-            artifactId = project.name
-            version = project.version
-
-            from components.java
-
-            artifact sourceJar
-            artifact javadocJar
-        }
-    }
-}
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,15 @@
 org.gradle.jvmargs=-Xmx1536m
 group=org.terasology.gestalt
-version=7.0.7-SNAPSHOT
+version=7.1.0-SNAPSHOT
+
+# Alternative resolution repo to use - this can be used to ignore "live" artifacts and only accept experimental ones.
+# alternativeResolutionRepo=http://artifactory.terasology.org/artifactory/virtual-nanoware-and-remote
+
 # Where to publish artifacts, if not to the default snapshot/release repos
 # Publishing a snapshot to a release-only repo will get an intended but quirky HTTP 409 Conflict error as of Nov 2014
-snapshotPublishRepo=http://artifactory.terasology.org/artifactory/libs-snapshot-local
-releasePublishRepo=http://artifactory.terasology.org/artifactory/libs-release-local
-# Override these values in ~/.gradle/gradle.properties
-gestaltMavenRepoUsername=
-gestaltMavenRepoPassword=
+#publishRepo=nanoware-snapshot-local
+
+# Credentials for publishing to Artifactory. Consider setting in ~/.gradle/gradle.properties
+# REMEMBER TO NOT CHECK IN ACTUAL CREDENTIAL FROM HERE!
+#mavenUser=
+#mavenPass=

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -1,0 +1,88 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Most typical common config, but not quite global
+apply plugin: 'java-library'
+apply plugin: 'maven-publish'
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+
+    sourceCompatibility(JavaVersion.VERSION_1_8)
+    targetCompatibility(JavaVersion.VERSION_1_8)
+}
+
+// Extra details provided for unit tests
+test {
+    useJUnit()
+
+    // ignoreFailures: Specifies whether the build should break when the verifications performed by this task fail.
+    ignoreFailures = true
+
+    // showStandardStreams: makes the standard streams (err and out) visible at console when running tests
+    testLogging.showStandardStreams = true
+
+    reports {
+        junitXml.enabled = true
+    }
+
+    // Arguments to include while running tests
+    jvmArgs '-Xms512m', '-Xmx1024m'
+}
+
+// In theory all Javadoc should be good and fixed, but it might be a bit much to entirely fail a build over. For now at least ...
+// Note: In IntelliJ 2020.1+ running a javadoc Gradle task may still *look* alarming in the UI, but errors should be ignored
+javadoc {
+    failOnError = false
+}
+
+publishing {
+    publications {
+        "$project.name"(MavenPublication) {
+            // Without this we get a .pom with no dependencies
+            from components.java
+
+            repositories {
+                maven {
+                    name = 'TerasologyOrg'
+                    allowInsecureProtocol true // 😱 - no https on our Artifactory yet
+
+                    if (rootProject.hasProperty("publishRepo")) {
+                        // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
+                        url = "http://artifactory.terasology.org/artifactory/$publishRepo"
+
+                        logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
+                    } else {
+                        // Support override from the environment to use a different target publish org
+                        String deducedPublishRepo = System.getenv()["PUBLISH_ORG"]
+                        if (deducedPublishRepo == null || deducedPublishRepo == "") {
+                            // If not then default
+                            deducedPublishRepo = "libs"
+                        }
+
+                        // Base final publish repo on whether we're building a snapshot or a release
+                        if (project.version.endsWith('SNAPSHOT')) {
+                            deducedPublishRepo += "-snapshot-local"
+                        } else {
+                            deducedPublishRepo += "-release-local"
+                        }
+
+                        logger.info("The final deduced publish repo is {}", deducedPublishRepo)
+                        url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
+                    }
+
+                    if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {
+                        credentials {
+                            username = "$mavenUser"
+                            password = "$mavenPass"
+                        }
+                        authentication {
+                            basic(BasicAuthentication)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testpack/moduleA/build.gradle
+++ b/testpack/moduleA/build.gradle
@@ -6,12 +6,6 @@ import org.reflections.scanners.SubTypesScanner
 import org.reflections.scanners.TypeAnnotationsScanner
 import org.reflections.serializers.JsonSerializer
 
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
 apply plugin: 'java'
 
 dependencies {

--- a/testpack/moduleB/build.gradle
+++ b/testpack/moduleB/build.gradle
@@ -1,12 +1,5 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
 apply plugin: 'java'
 
 dependencies {

--- a/testpack/moduleC/build.gradle
+++ b/testpack/moduleC/build.gradle
@@ -1,13 +1,5 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
 apply plugin: 'java'
 
 dependencies {

--- a/testpack/moduleD/build.gradle
+++ b/testpack/moduleD/build.gradle
@@ -1,13 +1,5 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
 apply plugin: 'java'
 
 dependencies {

--- a/testpack/moduleF/build.gradle
+++ b/testpack/moduleF/build.gradle
@@ -1,7 +1,5 @@
-
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-
 apply plugin: 'java'
 
 dependencies {

--- a/testpack/testpack-api/build.gradle
+++ b/testpack/testpack-api/build.gradle
@@ -1,26 +1,5 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * This is a Gradle build file:
- * - Gradle Homepage: http://gradle.org/
- * - Gradle Documentation: http://gradle.org/documentation
- * - View tasks for this project: $ gradlew tasks
- */
-
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 apply plugin: 'java'
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
Includes #103

Tested locally in Android Studio with test publishing to the Nanoware snapshot repo in Artifactory along with regular Jenkins snapshot builds (although without Android) via http://jenkins.terasology.io/teraorg/job/Nanoware/job/Gestalt/job/release%252Fv7.x/

Made to be very similar to the build-related files in the v8.x line

This is the first time we will be able to release the v7.x line via Jenkins _properly_ - although again still without Android - might either have to publish that from a local Android workspace or wait till we have an Android agent. So DS may have to wait a bit.