### PR TITLE
chore: update asset scheme

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -102,7 +102,7 @@ public abstract class Asset<T extends AssetData> {
         if(rootNode == null) {
             return Collections::emptyIterator;
         }
-        return () -> new Iterator<>() {
+        return () -> new Iterator<WeakReference<Asset<T>>>() {
             AssetNode<T> node = null;
 
             @Override

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -70,20 +70,6 @@ public abstract class Asset<T extends AssetData> {
         SoftReference<Asset<T>> reference;
         AssetNode<T> next;
 
-        protected void clearParent() {
-            Asset<T> instance = reference == null ? null: reference.get();
-            if(instance != null) {
-                instance.parent = null;
-            }
-        }
-
-        protected void setParent(Asset<T> parent) {
-            Asset<T> instance = reference == null ? null: reference.get();
-            if(instance != null) {
-                instance.parent = parent;
-            }
-        }
-
         protected boolean hasValidAsset() {
             Asset<T> instance = reference == null ? null: reference.get();
             if(instance == null) {

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -1,19 +1,5 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.gestalt.assets;
 
 import com.google.common.base.Preconditions;
@@ -77,16 +63,20 @@ public abstract class Asset<T extends AssetData> {
         }
     }
 
-    protected Iterable<WeakReference<Asset<T>>> instances() {
+    /**
+     * return all the instances that are associated with this type of asset.
+     * @return instances
+     */
+    protected final Iterable<WeakReference<Asset<T>>> instances() {
         if (this.parent != null) {
             return parent.instances();
         }
         return instances;
     }
 
-    protected void cleanup() {
-        if(this.parent != null) {
-            parent.cleanup();
+    private void compactInstances() {
+        if (this.parent != null) {
+            parent.compactInstances();
             return;
         }
         Iterator<WeakReference<Asset<T>>> iter = instances.iterator();
@@ -182,6 +172,11 @@ public abstract class Asset<T extends AssetData> {
         return (Optional<U>) assetCopy;
     }
 
+    /**
+     * return the non-instanced version of this asset. if the asset is already the normal
+     * type then it returns itself.
+     * @return non-instanced version of this Asset
+     */
     public final Asset<T> getNormalAsset() {
         if(parent == null) {
             return this;
@@ -194,6 +189,7 @@ public abstract class Asset<T extends AssetData> {
      */
     public final synchronized void dispose() {
         if (!disposed) {
+            compactInstances();
             disposed = true;
             assetType.onAssetDisposed(this);
             disposalHook.dispose();

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -54,15 +54,15 @@ import java.util.Optional;
 @ThreadSafe
 public abstract class Asset<T extends AssetData> {
 
+    AssetNode<Asset<T>> next;
+    Asset<?> parent;
+
     private final ResourceUrn urn;
     private final AssetType<?, T> assetType;
     private final DisposalHook disposalHook = new DisposalHook();
     private volatile boolean disposed;
 
-    protected AssetNode<Asset<T>> next;
-    protected Asset<?> parent;
-
-    protected static class AssetNode<U extends Asset<?>> {
+    static class AssetNode<U extends Asset<?>> {
         public AssetNode(U root,U instance) {
             this.reference = new SoftReference<>(instance);
             instance.parent = root;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -175,10 +175,11 @@ public abstract class Asset<T extends AssetData> {
 
     /**
      * return the non-instanced version of this asset. if the asset is already the normal
-     * type then it returns itself.
+     * type then it returns itself. instanced assets are temporary copies from the normal loaded instances.
+     *
      * @return non-instanced version of this Asset
      */
-    public final Asset<T> getConcreteAsset() {
+    public final Asset<T> getNormalAsset() {
         if (parent == null) {
             return this;
         }
@@ -192,7 +193,6 @@ public abstract class Asset<T extends AssetData> {
         if (!disposed) {
             compactInstances();
             disposed = true;
-            assetType.onAssetDisposed(this);
             disposalHook.dispose();
             if(parent == null) {
                 for (WeakReference<Asset<T>> inst : this.instances()) {

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -17,8 +17,6 @@
 package org.terasology.gestalt.assets;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
-import com.sun.org.apache.xml.internal.dtm.ref.EmptyIterator;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -52,6 +52,22 @@ public abstract class Asset<T extends AssetData> {
     private final DisposalHook disposalHook = new DisposalHook();
     private volatile boolean disposed;
 
+
+    /**
+     * The constructor for an asset. It is suggested that implementing classes provide a constructor taking both the urn, and an initial AssetData to load.
+     *
+     * @param urn       The urn identifying the asset.
+     * @param assetType The asset type this asset belongs to.
+     */
+    protected Asset(ResourceUrn urn, AssetType<?, T> assetType) {
+        Preconditions.checkNotNull(urn);
+        Preconditions.checkNotNull(assetType);
+        instances = urn.isInstance() ? Collections.emptyList() : Lists.newArrayList();
+        this.urn = urn;
+        this.assetType = assetType;
+        assetType.registerAsset(this, disposalHook);
+    }
+
     private void appendInstance(Asset<T> asset) {
         if (parent == null) {
             Preconditions.checkArgument(!getUrn().isInstance());
@@ -87,21 +103,6 @@ public abstract class Asset<T extends AssetData> {
                 iter.remove();
             }
         }
-    }
-
-    /**
-     * The constructor for an asset. It is suggested that implementing classes provide a constructor taking both the urn, and an initial AssetData to load.
-     *
-     * @param urn       The urn identifying the asset.
-     * @param assetType The asset type this asset belongs to.
-     */
-    protected Asset(ResourceUrn urn, AssetType<?, T> assetType) {
-        Preconditions.checkNotNull(urn);
-        Preconditions.checkNotNull(assetType);
-        instances = urn.isInstance() ? Collections.emptyList(): Lists.newArrayList();
-        this.urn = urn;
-        this.assetType = assetType;
-        assetType.registerAsset(this, disposalHook);
     }
 
     /**
@@ -177,8 +178,8 @@ public abstract class Asset<T extends AssetData> {
      * type then it returns itself.
      * @return non-instanced version of this Asset
      */
-    public final Asset<T> getNormalAsset() {
-        if(parent == null) {
+    public final Asset<T> getConcreteAsset() {
+        if (parent == null) {
             return this;
         }
         return parent;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
@@ -115,14 +115,13 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      */
     @SuppressWarnings("unchecked")
     public void processDisposal() {
-        Reference<? extends Asset<U>> ref = disposalQueue.poll();
         Set<ResourceUrn> urns = new HashSet<>();
-        while (ref != null) {
+        Reference<? extends Asset<U>> ref = null;
+        while ((ref = disposalQueue.poll()) != null) {
             AssetReference<? extends Asset<U>> assetRef = (AssetReference<? extends Asset<U>>) ref;
             urns.add(assetRef.parentUrn);
             assetRef.dispose();
             references.remove(assetRef);
-            ref = disposalQueue.poll();
         }
         for (ResourceUrn urn : urns) {
             disposeAsset(urn);
@@ -258,17 +257,6 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
                 loadedAssets.put(asset.getUrn(), new SoftReference<T>(assetClass.cast(asset)));
             }
             references.add(new AssetReference<>(asset, disposalQueue, disposer));
-        }
-    }
-
-    /**
-     * Notifies the asset type when an asset is disposed
-     *
-     * @param asset The asset that was disposed.
-     */
-    void onAssetDisposed(Asset<U> asset) {
-        if (!asset.getUrn().isInstance()) {
-            disposeAsset(asset.getUrn());
         }
     }
 

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
@@ -159,13 +159,13 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     public synchronized void disposeAll() {
         loadedAssets.values().forEach(k -> {
             Asset<U> asset = k.get();
-            if(asset != null) {
+            if (asset != null) {
                 asset.dispose();
                 Asset.AssetNode<Asset<U>> current = asset.next;
-                while(current != null){
+                while (current != null) {
                     SoftReference<Asset<U>> target = current.reference;
                     Asset<U> en = target.get();
-                    if(en != null) {
+                    if (en != null) {
                         en.dispose();
                     }
                     current = current.next;
@@ -288,9 +288,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
         }
     }
 
-
     private boolean addAsset(T targetAsset) {
-
         ResourceUrn targetUrn = targetAsset.getUrn();
         ResourceUrn parentUrn = targetUrn.getParentUrn();
 
@@ -656,7 +654,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @return A list of all the loaded assets.
      */
     public Set<T> getLoadedAssets() {
-        return ImmutableSet.copyOf(loadedAssets.values().stream().map(Reference::get).filter(Objects::nonNull).collect(Collectors.toSet()));
+        return loadedAssets.values().stream().map(Reference::get).filter(Objects::nonNull).collect(Collectors.toSet());
     }
 
     /**
@@ -717,7 +715,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
         }
     }
 
-    public final class AssetReference<T extends Asset<?>> extends PhantomReference<T> {
+    private final class AssetReference<T extends Asset<?>> extends PhantomReference<T> {
 
         private final DisposalHook disposalHook;
         public final ResourceUrn parentUrn;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
@@ -301,7 +301,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     @SuppressWarnings("unchecked")
     public Optional<T> getInstanceAsset(ResourceUrn urn) {
         Optional<? extends T> parentAsset = getAsset(urn.getParentUrn());
-        if (parentAsset.isPresent()) {
+        if (parentAsset.isPresent() && !parentAsset.get().isDisposed()) {
             return parentAsset.get().createInstance();
         } else {
             return Optional.empty();
@@ -411,9 +411,12 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     private Optional<T> getNormalAsset(ResourceUrn urn) {
         ResourceUrn redirectUrn = followRedirects(urn);
         Reference<T> reference = loadedAssets.get(redirectUrn);
-        T asset = reference == null ? null: reference.get();
+        T asset = reference == null ? null : reference.get();
         if (asset == null) {
             return reload(redirectUrn);
+        }
+        if (asset.isDisposed()) {
+            return Optional.empty();
         }
         return Optional.ofNullable(asset);
     }

--- a/gestalt-asset-core/src/test/java/virtualModules/test/stubs/book/Book.java
+++ b/gestalt-asset-core/src/test/java/virtualModules/test/stubs/book/Book.java
@@ -35,8 +35,7 @@ public class Book extends Asset<BookData> {
     private ImmutableList<String> lines = ImmutableList.of();
 
     public Book(ResourceUrn urn, BookData data, AssetType<?, BookData> type) {
-        super(urn, type);
-        setDisposableResource(new DisposalAction(urn));
+        super(urn, type, new DisposalAction(urn));
         reload(data);
     }
 


### PR DESCRIPTION
this changes how assets work with the assetmanager and attempts to address some problems.

1. for transient assets the current scheme will slowly leak weak pointers since they are not properly removed from the multimap. 
2. there is now just a single map from a resource urn to the start of a chain of assets. (non-transient assets use soft-reference and transient assets use a weakreference but weak references use a strong reference so the non-transient asset so it's not disposed unless all transient assets have been disposed in the chain.  
  - the non-transient asset is always placed first and all transient assets use a weak reference
  - each asset is chained from the beginning forward as new assets are added they are placed at the beginning of the chain unless if its a non-transient asset then it skips the first entry
  
![image](https://user-images.githubusercontent.com/854359/116014612-f79b1c00-a5ea-11eb-8d40-d1c51142afd8.png)
