### PR TITLE
build(gestalt-module): semver is part of the ABI

### DIFF
--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.apache.commons:commons-vfs2:2.2'
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
-    implementation "com.github.zafarkhaja:java-semver:0.10.0"
+    api "com.github.zafarkhaja:java-semver:0.10.0"
 
     testImplementation project(":testpack:testpack-api")
     testImplementation "ch.qos.logback:logback-classic:$logback_version"


### PR DESCRIPTION
as of when Version.semver was changed from private to package-private.

The way to avoid this would be to make a public Version interface and have all fields and method parameters involving semver.Version be on private classes.

Which we could do, but is maybe the sort of thing to lump in with later changes to the DependencyInfo and VersionRange APIs.