### PR TITLE
chore: handle disposable action outside of the constructor

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -62,7 +62,7 @@ public abstract class Asset<T extends AssetData> {
      * @param urn       The urn identifying the asset.
      * @param assetType The asset type this asset belongs to.
      */
-    public Asset(ResourceUrn urn, AssetType<?, T> assetType) {
+    protected Asset(ResourceUrn urn, AssetType<?, T> assetType) {
         Preconditions.checkNotNull(urn);
         Preconditions.checkNotNull(assetType);
         this.urn = urn;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -71,21 +71,13 @@ public abstract class Asset<T extends AssetData> {
     }
 
     /**
-     * The constructor for an asset. It is suggested that implementing classes provide a constructor taking both the urn, and an initial AssetData to load.
-     *
-     * @param urn            The urn identifying the asset.
-     * @param assetType      The asset type this asset belongs to.
+     * set a resource handler so the disposable hook can clean up resources not managed by the JVM
      * @param resource        A resource to close when disposing this class.  The resource must not have a reference to this asset -
      *                       this would prevent it being garbage collected. It must be a static inner class, or not contained in the asset class
      *                       (or an anonymous class defined in a static context). A warning will be logged if this is not the case.
      */
-    public Asset(ResourceUrn urn, AssetType<?, T> assetType, DisposableResource resource) {
-        Preconditions.checkNotNull(urn);
-        Preconditions.checkNotNull(assetType);
-        this.urn = urn;
-        this.assetType = assetType;
-        disposalHook.setDisposableResource(resource);
-        assetType.registerAsset(this, disposalHook);
+    protected void setDisposableResource(DisposableResource resource) {
+        this.disposalHook.setDisposableResource(resource);
     }
 
     /**

--- a/gestalt-asset-core/src/test/java/virtualModules/test/stubs/book/Book.java
+++ b/gestalt-asset-core/src/test/java/virtualModules/test/stubs/book/Book.java
@@ -35,7 +35,8 @@ public class Book extends Asset<BookData> {
     private ImmutableList<String> lines = ImmutableList.of();
 
     public Book(ResourceUrn urn, BookData data, AssetType<?, BookData> type) {
-        super(urn, type, new DisposalAction(urn));
+        super(urn, type);
+        setDisposableResource(new DisposalAction(urn));
         reload(data);
     }
 


### PR DESCRIPTION
having this property as a constructor parameter makes it really hard to hide the underlying implementation without passing it through a private constructor. the way this has been worked into the engine is to make the function call private and have a static  method create the resource so the constructor can then assign the resource to a local variable. for all intensive purposes the resource is hidden from the implementing class unless you do this strange proxy call stuff. 

```
private OpenGLMesh(ResourceUrn urn, AssetType<?, MeshData> assetType, DisposableResource resource, MeshData data, LwjglGraphicsProcessing graphicsProcessing) {
        super(urn, assetType, resource);
        graphicsProcessing.asynchToDisplayThread(() -> {
            reload(data);
        });
        this.resource = resource;
    }

    public static OpenGLMesh create(ResourceUrn urn, AssetType<?, MeshData> assetType, MeshData data,
                                    LwjglGraphicsProcessing graphicsProcessing) {
        return new OpenGLMesh(urn, assetType, data, new DisposalAction(), graphicsProcessing);
    }
```