### PR TITLE
Process sub-classes when indexing & fix ClassIndex directory load path

### DIFF
--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/index/UrlClassIndex.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/index/UrlClassIndex.java
@@ -34,7 +34,7 @@ public class UrlClassIndex implements ClassIndex {
 
     public static ClassIndex byDirectory(File file) {
         try {
-            return new UrlClassIndex(new URL(file.toURI().toURL(), "/" + METAINF));
+            return new UrlClassIndex(new URL(file.toURI().toURL(), METAINF));
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Description
This is needed for module loading and working abilities with MovingBlocks/DestinationSol#586.

Destination Sol abilities use config sub-classes (convention-based), which were not being indexed previously. The code should now index all sub-classes recursively for sub-type indexes.

When developing modules, it is common to use the directory module format with a source workspace. This was broken though, due to the use of an absolute URL path over a relative one.
> If the spec's path component begins with a slash character "/" then the path is treated as absolute and the spec path replaces the context path. 
> https://docs.oracle.com/javase/7/docs/api/java/net/URL.html#URL(java.net.URL,%20java.lang.String)
### Testing
- If directory modules work in Destination Sol, then this works
- If abilities work in Destination Sol, then this works