### PR TITLE
backport(v7): refactor!: rename `Component::copy` to `Component::copyFrom` (#122)

### DIFF
--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/Component.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/Component.java
@@ -34,5 +34,5 @@ public interface Component<T extends Component> {
      * Copies the values from another component. This is expected to be of the same type.
      * @param other The component to copy
      */
-    void copy(T other);
+    void copyFrom(T other);
 }

--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/EmptyComponent.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/EmptyComponent.java
@@ -11,6 +11,6 @@ package org.terasology.gestalt.entitysystem.component;
 public abstract class EmptyComponent<T extends EmptyComponent> implements Component<T> {
 
     @Override
-    public void copy(T other) {
+    public void copyFrom(T other) {
     }
 }

--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/management/AbstractComponentTypeFactory.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/management/AbstractComponentTypeFactory.java
@@ -20,7 +20,6 @@ import android.support.annotation.NonNull;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Converter;
-import com.google.common.collect.Lists;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +34,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -66,7 +64,7 @@ public abstract class AbstractComponentTypeFactory implements ComponentTypeFacto
         if (copyConstructor == null) {
             copyConstructor = (T from) -> {
                 T result = emptyConstructor.get();
-                result.copy(from);
+                result.copyFrom(from);
                 return result;
             };
         }

--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/store/ArrayComponentStore.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/store/ArrayComponentStore.java
@@ -66,7 +66,7 @@ public class ArrayComponentStore<T extends Component<T>> implements ComponentSto
     public boolean get(int entityId, T into) {
         T value = store[entityId];
         if (value != null) {
-            into.copy(store[entityId]);
+            into.copyFrom(store[entityId]);
             return true;
         }
         return false;
@@ -78,7 +78,7 @@ public class ArrayComponentStore<T extends Component<T>> implements ComponentSto
             store[entityId] = type.createCopy(component);
             return true;
         } else {
-            store[entityId].copy(component);
+            store[entityId].copyFrom(component);
             return false;
         }
     }
@@ -126,7 +126,7 @@ public class ArrayComponentStore<T extends Component<T>> implements ComponentSto
 
         @Override
         public void getComponent(Component<T> component) {
-            component.copy(store[index]);
+            component.copyFrom(store[index]);
         }
 
         @Override

--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/store/SparseComponentStore.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/component/store/SparseComponentStore.java
@@ -59,7 +59,7 @@ public class SparseComponentStore<T extends Component<T>> implements ComponentSt
         if (source == null) {
             return false;
         }
-        into.copy(source);
+        into.copyFrom(source);
         return true;
     }
 
@@ -70,7 +70,7 @@ public class SparseComponentStore<T extends Component<T>> implements ComponentSt
             store.put(entityId, type.createCopy(component));
             return true;
         } else {
-            stored.copy(component);
+            stored.copyFrom(component);
             return false;
         }
     }
@@ -119,7 +119,7 @@ public class SparseComponentStore<T extends Component<T>> implements ComponentSt
 
         @Override
         public void getComponent(Component<T> component) {
-            component.copy(iterator.value());
+            component.copyFrom(iterator.value());
         }
     }
 

--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/prefab/GeneratedFromRecipeComponent.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/prefab/GeneratedFromRecipeComponent.java
@@ -42,7 +42,7 @@ public final class GeneratedFromRecipeComponent implements Component<GeneratedFr
     }
 
     @Override
-    public void copy(GeneratedFromRecipeComponent other) {
+    public void copyFrom(GeneratedFromRecipeComponent other) {
         this.entityRecipe = other.entityRecipe;
     }
 }

--- a/gestalt-entity-system/src/test/java/modules/test/components/ArrayContainingComponent.java
+++ b/gestalt-entity-system/src/test/java/modules/test/components/ArrayContainingComponent.java
@@ -10,7 +10,7 @@ public class ArrayContainingComponent implements Component<ArrayContainingCompon
     public List<String> strings = new ArrayList<>();
 
     @Override
-    public void copy(ArrayContainingComponent other) {
+    public void copyFrom(ArrayContainingComponent other) {
         strings.clear();
         strings.addAll(other.strings);
     }

--- a/gestalt-entity-system/src/test/java/modules/test/components/BasicComponent.java
+++ b/gestalt-entity-system/src/test/java/modules/test/components/BasicComponent.java
@@ -42,7 +42,7 @@ public final class BasicComponent implements Component<BasicComponent> {
     }
 
     public BasicComponent(BasicComponent other) {
-        copy(other);
+        copyFrom(other);
         logger.info("Copy constructor called");
     }
 
@@ -78,7 +78,7 @@ public final class BasicComponent implements Component<BasicComponent> {
         this.count = count;
     }
 
-    public void copy(BasicComponent other) {
+    public void copyFrom(BasicComponent other) {
         this.name = other.name;
         this.description = other.description;
         this.count = other.count;

--- a/gestalt-entity-system/src/test/java/modules/test/components/PublicAttributeComponent.java
+++ b/gestalt-entity-system/src/test/java/modules/test/components/PublicAttributeComponent.java
@@ -7,7 +7,7 @@ public class PublicAttributeComponent implements Component<PublicAttributeCompon
     public String name = "";
 
     @Override
-    public void copy(PublicAttributeComponent other) {
+    public void copyFrom(PublicAttributeComponent other) {
         this.name = other.name;
     }
 }

--- a/gestalt-entity-system/src/test/java/modules/test/components/Reference.java
+++ b/gestalt-entity-system/src/test/java/modules/test/components/Reference.java
@@ -39,7 +39,7 @@ public final class Reference implements Component<Reference> {
     }
 
     public Reference(Reference other) {
-        copy(other);
+        copyFrom(other);
     }
 
     public EntityRef getReference() {
@@ -59,7 +59,7 @@ public final class Reference implements Component<Reference> {
         this.references.addAll(references);
     }
 
-    public void copy(Reference other) {
+    public void copyFrom(Reference other) {
         setReferences(other.references);
         this.reference = other.reference;
     }

--- a/gestalt-entity-system/src/test/java/modules/test/components/Sample.java
+++ b/gestalt-entity-system/src/test/java/modules/test/components/Sample.java
@@ -30,7 +30,7 @@ public final class Sample implements Component<Sample> {
     }
 
     public Sample(Sample other) {
-        copy(other);
+        copyFrom(other);
     }
 
     public String getName() {
@@ -49,7 +49,7 @@ public final class Sample implements Component<Sample> {
         this.description = description;
     }
 
-    public void copy(Sample other) {
+    public void copyFrom(Sample other) {
         this.name = other.name;
         this.description = other.description;
     }

--- a/gestalt-entity-system/src/test/java/modules/test/components/Second.java
+++ b/gestalt-entity-system/src/test/java/modules/test/components/Second.java
@@ -34,7 +34,7 @@ public final class Second implements Component<Second> {
     }
 
     public Second(Second other) {
-        copy(other);
+        copyFrom(other);
     }
 
     public String getName() {
@@ -55,7 +55,7 @@ public final class Second implements Component<Second> {
         this.dirty = true;
     }
 
-    public void copy(Second other) {
+    public void copyFrom(Second other) {
         this.name = other.name;
         this.description = other.description;
         this.dirty = true;

--- a/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/component/management/ComponentManagerTest.java
+++ b/gestalt-entity-system/src/test/java/org/terasology/gestalt/entitysystem/component/management/ComponentManagerTest.java
@@ -114,7 +114,7 @@ public abstract class ComponentManagerTest {
         }
 
         @Override
-        public void copy(MismatchedPropertiesComponent other) {
+        public void copyFrom(MismatchedPropertiesComponent other) {
             this.stringProperty = other.stringProperty;
         }
     }

--- a/gestalt-es-perf/src/test/java/modules/test/components/ArrayContainingComponent.java
+++ b/gestalt-es-perf/src/test/java/modules/test/components/ArrayContainingComponent.java
@@ -10,7 +10,7 @@ public class ArrayContainingComponent implements Component<ArrayContainingCompon
     public List<String> strings = new ArrayList<>();
 
     @Override
-    public void copy(ArrayContainingComponent other) {
+    public void copyFrom(ArrayContainingComponent other) {
         strings.clear();
         strings.addAll(other.strings);
     }

--- a/gestalt-es-perf/src/test/java/modules/test/components/BasicComponent.java
+++ b/gestalt-es-perf/src/test/java/modules/test/components/BasicComponent.java
@@ -42,7 +42,7 @@ public final class BasicComponent implements Component<BasicComponent> {
     }
 
     public BasicComponent(BasicComponent other) {
-        copy(other);
+        copyFrom(other);
         logger.info("Copy constructor called");
     }
 
@@ -78,7 +78,7 @@ public final class BasicComponent implements Component<BasicComponent> {
         this.count = count;
     }
 
-    public void copy(BasicComponent other) {
+    public void copyFrom(BasicComponent other) {
         this.name = other.name;
         this.description = other.description;
         this.count = other.count;

--- a/gestalt-es-perf/src/test/java/modules/test/components/Empty.java
+++ b/gestalt-es-perf/src/test/java/modules/test/components/Empty.java
@@ -27,9 +27,9 @@ public final class Empty implements Component<Empty> {
     }
 
     public Empty(Empty other) {
-        copy(other);
+        copyFrom(other);
     }
 
-    public void copy(Empty other) {
+    public void copyFrom(Empty other) {
     }
 }

--- a/gestalt-es-perf/src/test/java/modules/test/components/PublicAttributeComponent.java
+++ b/gestalt-es-perf/src/test/java/modules/test/components/PublicAttributeComponent.java
@@ -7,7 +7,7 @@ public class PublicAttributeComponent implements Component<PublicAttributeCompon
     public String name = "";
 
     @Override
-    public void copy(PublicAttributeComponent other) {
+    public void copyFrom(PublicAttributeComponent other) {
         this.name = other.name;
     }
 }

--- a/gestalt-es-perf/src/test/java/modules/test/components/Sample.java
+++ b/gestalt-es-perf/src/test/java/modules/test/components/Sample.java
@@ -29,7 +29,7 @@ public final class Sample implements Component<Sample> {
     }
 
     public Sample(Sample other) {
-        copy(other);
+        copyFrom(other);
     }
 
     public String getName() {
@@ -48,7 +48,7 @@ public final class Sample implements Component<Sample> {
         this.description = description;
     }
 
-    public void copy(Sample other) {
+    public void copyFrom(Sample other) {
         this.name = other.name;
         this.description = other.description;
     }

--- a/gestalt-es-perf/src/test/java/modules/test/components/Second.java
+++ b/gestalt-es-perf/src/test/java/modules/test/components/Second.java
@@ -32,7 +32,7 @@ public final class Second implements Component<Second> {
     }
 
     public Second(Second other) {
-        copy(other);
+        copyFrom(other);
     }
 
     public String getName() {
@@ -51,7 +51,7 @@ public final class Second implements Component<Second> {
         this.description = description;
     }
 
-    public void copy(Second other) {
+    public void copyFrom(Second other) {
         this.name = other.name;
         this.description = other.description;
     }

--- a/gestalt-es-perf/src/test/java/org/terasology/gestalt/entitysystem/component/management/perf/ComponentManagerTest.java
+++ b/gestalt-es-perf/src/test/java/org/terasology/gestalt/entitysystem/component/management/perf/ComponentManagerTest.java
@@ -118,7 +118,7 @@ public abstract class ComponentManagerTest {
         }
 
         @Override
-        public void copy(MismatchedPropertiesComponent other) {
+        public void copyFrom(MismatchedPropertiesComponent other) {
             this.stringProperty = other.stringProperty;
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1536m
 group=org.terasology.gestalt
-version=7.1.1-SNAPSHOT
+version=7.2.0-SNAPSHOT
 
 # Alternative resolution repo to use - this can be used to ignore "live" artifacts and only accept experimental ones.
 # alternativeResolutionRepo=http://artifactory.terasology.org/artifactory/virtual-nanoware-and-remote

--- a/testpack/moduleF/src/main/java/org/terasology/gestalt/example/modulef/MyComponent.java
+++ b/testpack/moduleF/src/main/java/org/terasology/gestalt/example/modulef/MyComponent.java
@@ -14,7 +14,7 @@ public class MyComponent implements Component<MyComponent> {
     }
 
     @Override
-    public void copy(MyComponent other) {
+    public void copyFrom(MyComponent other) {
         this.name = other.name;
     }
 }


### PR DESCRIPTION
Backport changes from #122 to `release/v7.x`.

- refactor: rename `Component::copy` to `Component::copyFrom`
- chore!: bump version to 7.2.0-SNAPSHOT

BREAKING CHANGES To fix incompatibilities simply rename implementations of `Component::copy` to `Component::copyFrom`.
