### PR TITLE
fix: remove only use of Android API 24 incompatible code

### DIFF
--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/management/ContextManager.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/management/ContextManager.java
@@ -33,7 +33,12 @@ import java.util.Deque;
 public final class ContextManager {
 
     private static final Logger logger = LoggerFactory.getLogger(ContextManager.class);
-    private static final ThreadLocal<Deque<Name>> CONTEXT_STACK = ThreadLocal.withInitial(Queues::newArrayDeque);
+    private static final ThreadLocal<Deque<Name>> CONTEXT_STACK = new ThreadLocal<Deque<Name>>() {
+        @Override
+        protected Deque<Name> initialValue() {
+            return Queues.newArrayDeque();
+        }
+    };
 
     private ContextManager() {
     }


### PR DESCRIPTION
I have been applying this patch for a while now to get Destination Sol working on my Android testing device, which runs Android 7.0 (API 24). It simply swaps an unavaliable convenience method for its equivalent.

This fixes #81.