### PR TITLE
ci: add android builds to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,11 @@
 pipeline {
     agent {
-        label "light"
+        label "android"
     }
     stages {
         stage('Build') {
             steps {
+                sh 'echo sdk.dir=/opt/android-sdk > local.properties'
                 sh './gradlew --info --console=plain jar'
             }
         }


### PR DESCRIPTION
This is just a small change that updates the `Jenkinsfile` to use the Android build agent and enables building/publishing the `gestalt-android` library. I also fixed a compilation error in `gestalt=android-testbed` that had been previously overlooked when re-naming `Component#copy` to `Component#copyFrom`.

This should fix #127.