### PR TITLE
[develop] feat(android): add new AssetManager-based modules source

### DIFF
--- a/gestalt-android/src/main/java/org/terasology/gestalt/android/AndroidAssetsFileSource.java
+++ b/gestalt-android/src/main/java/org/terasology/gestalt/android/AndroidAssetsFileSource.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.gestalt.android;
+
+import android.content.res.AssetManager;
+import android.support.annotation.NonNull;
+import org.terasology.gestalt.module.resources.FileReference;
+import org.terasology.gestalt.module.resources.ModuleFileSource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A {@link ModuleFileSource} that can be used to access files stored in the "assets" directory of an Android APK.
+ * It requires an {@link AssetManager} instance to use, which can be obtained using {@link android.content.Context#getAssets()}.
+ */
+public class AndroidAssetsFileSource implements ModuleFileSource {
+    private final AssetManager assetManager;
+    private final String moduleRoot;
+
+    public AndroidAssetsFileSource(AssetManager assetManager, String moduleRoot) {
+        this.assetManager = assetManager;
+        this.moduleRoot = moduleRoot;
+    }
+
+    /**
+     * Obtains the handle to a specific file
+     *
+     * @param filepath The path to the file. Should not be empty
+     * @return The requested file, or {@link Optional#empty()} if it doesn't exist
+     */
+    @Override
+    public Optional<FileReference> getFile(List<String> filepath) {
+        try {
+            String path = getPath(filepath);
+            assetManager.open(path).close();
+            return Optional.of(new AssetsFileReference(filepath.get(filepath.size() - 1), path));
+        } catch (Exception ignore) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Finds all files within a path
+     *
+     * @param recursive Whether to recurse through subpaths
+     * @param path      The path to search
+     * @return A collection of handles to all files in the give path
+     */
+    @Override
+    public Collection<FileReference> getFilesInPath(boolean recursive, List<String> path) {
+        List<FileReference> files = new ArrayList<>();
+        String rootPath = getPath(path);
+
+        try {
+            for (String subPath : assetManager.list(moduleRoot + "/" + rootPath)) {
+                files.add(new AssetsFileReference(subPath, rootPath));
+                if (recursive) {
+                    files.addAll(getFilesInPath(recursive,rootPath + "/" + subPath));
+                }
+            }
+        } catch (IOException ignore) {
+            return files;
+        }
+
+        return files;
+    }
+
+    /**
+     * Finds all subpaths in the given path
+     *
+     * @param fromPath The path to search
+     * @return A list of the immediate subpaths in the given path
+     */
+    @Override
+    public Set<String> getSubpaths(List<String> fromPath) {
+        Set<String> subPaths = new HashSet<>();
+        String rootPath = getPath(fromPath);
+
+        try {
+            for (String subPath : assetManager.list(moduleRoot + "/" + rootPath)) {
+                subPaths.add(subPath);
+            }
+        } catch (IOException ignore) {
+            return subPaths;
+        }
+
+        return subPaths;
+    }
+
+    /**
+     * Returns an iterator over elements of type {@code T}.
+     *
+     * @return an Iterator.
+     */
+    @NonNull
+    @Override
+    public Iterator<FileReference> iterator() {
+        return getFilesInPath(true, Collections.singletonList("")).iterator();
+    }
+
+    private String getPath(List<String> parts) {
+        StringBuilder pathBuilder = new StringBuilder();
+        for (int partNo = 0; partNo < parts.size(); partNo++) {
+            pathBuilder.append(parts.get(partNo));
+            if (partNo != parts.size() - 1) {
+                pathBuilder.append('/');
+            }
+        }
+        return pathBuilder.toString();
+    }
+
+    private class AssetsFileReference implements FileReference {
+        private final String name;
+        private final String path;
+
+        public AssetsFileReference(String name, String path) {
+            this.name = name;
+            this.path = path;
+        }
+
+        /**
+         * @return The name of the file
+         */
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @return The path to the file (within the file source), excluding the file name
+         */
+        @Override
+        public List<String> getPath() {
+            return Arrays.asList(path.split("/"));
+        }
+
+        /**
+         * @return A new InputStream for reading the file. Closing the stream is the duty of the caller
+         * @throws IOException If there is an exception opening the file
+         */
+        @Override
+        public InputStream open() throws IOException {
+            return assetManager.open(moduleRoot + "/" + path + "/" + name);
+        }
+    }
+}

--- a/gestalt-android/src/main/java/org/terasology/gestalt/android/AndroidModulePathScanner.java
+++ b/gestalt-android/src/main/java/org/terasology/gestalt/android/AndroidModulePathScanner.java
@@ -19,9 +19,10 @@ package org.terasology.gestalt.android;
 import android.content.res.AssetManager;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
-import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.gestalt.di.index.CompoundClassIndex;
+import org.terasology.gestalt.di.index.UrlClassIndex;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleMetadata;
 import org.terasology.gestalt.module.ModuleMetadataJsonAdapter;
@@ -30,7 +31,6 @@ import org.terasology.gestalt.module.ModuleRegistry;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,22 +44,24 @@ import java.util.List;
  * A {@link ModulePathScanner} derivative that scans the APK assets directory on Android for modules.
  * It uses {@link AndroidAssetsFileSource} to create modules that directly use these files, removing the need to copy
  * the modules into the app's data directory first.
+ *
+ * For code modules, the dexes/jars are copied into app storage but everything else is read directly from the APK.
  */
 public class AndroidModulePathScanner extends ModulePathScanner {
     private static final Logger logger = LoggerFactory.getLogger(AndroidModulePathScanner.class);
     private final AssetManager assetManager;
-    private final File moduleDexesCache;
+    private final File moduleCodeCache;
 
-    public AndroidModulePathScanner(AssetManager assetManager, File moduleDexesCache) {
-        super();
+    public AndroidModulePathScanner(AssetManager assetManager, File moduleCodeCache) {
+        super(null);
         this.assetManager = assetManager;
-        this.moduleDexesCache = moduleDexesCache;
+        this.moduleCodeCache = moduleCodeCache;
     }
 
-    private void deleteModuleDexesCache(File file) {
+    private void deleteModuleCodeCache(File file) {
         if (file.isDirectory()) {
             for (String subPath : file.list()) {
-                deleteModuleDexesCache(new File(file, subPath));
+                deleteModuleCodeCache(new File(file, subPath));
             }
         }
         file.delete();
@@ -67,8 +69,8 @@ public class AndroidModulePathScanner extends ModulePathScanner {
 
     @Override
     public void scan(ModuleRegistry registry, Collection<File> paths) {
-        if (moduleDexesCache.exists()) {
-            deleteModuleDexesCache(moduleDexesCache);
+        if (moduleCodeCache.exists()) {
+            deleteModuleCodeCache(moduleCodeCache);
         }
 
         for (File path : paths) {
@@ -89,24 +91,16 @@ public class AndroidModulePathScanner extends ModulePathScanner {
                         continue;
                     }
 
-                    Reflections reflections = new Reflections();
-                    try {
-                        InputStream reflectionsFile = assetManager.open(fullModulePath + "/build/classes/reflections.cache");
-                        reflections.collect(reflectionsFile);
-                    } catch (FileNotFoundException ignore) {
-                        logger.warn("No reflections cache found for module. Is it an asset-only module?");
-                    } catch (Exception e) {
-                        logger.error("Error reading reflections", e);
-                    }
+                    CompoundClassIndex classIndex = new CompoundClassIndex();
 
                     List<File> classpaths = new ArrayList<>();
                     try {
-                        for (String moduleDex : assetManager.list(fullModulePath + "/build/dexes")) {
-                            if (moduleDex.endsWith(".dex")) {
-                                new File(moduleDexesCache, modulePath).mkdirs();
-                                File cachedModuleDex = new File(moduleDexesCache, modulePath + "/" + moduleDex);
-                                try (InputStream inputStream = assetManager.open(fullModulePath + "/build/dexes/" + moduleDex)) {
-                                    try (FileOutputStream outputStream = new FileOutputStream(cachedModuleDex)) {
+                        for (String moduleCode : assetManager.list(fullModulePath + "/build/dexes")) {
+                            if (moduleCode.endsWith(".dex") || moduleCode.endsWith(".jar")) {
+                                new File(moduleCodeCache, modulePath).mkdirs();
+                                File cachedModuleCode = new File(moduleCodeCache, modulePath + "/" + moduleCode);
+                                try (InputStream inputStream = assetManager.open(fullModulePath + "/build/dexes/" + moduleCode)) {
+                                    try (FileOutputStream outputStream = new FileOutputStream(cachedModuleCode)) {
                                         ByteStreams.copy(inputStream, outputStream);
                                     } catch (Exception e) {
                                         e.printStackTrace();
@@ -114,7 +108,13 @@ public class AndroidModulePathScanner extends ModulePathScanner {
                                 } catch (IOException e) {
                                     e.printStackTrace();
                                 }
-                                classpaths.add(cachedModuleDex);
+                                classpaths.add(cachedModuleCode);
+                                if (moduleCode.endsWith(".jar")) {
+                                    classIndex.add(UrlClassIndex.byArchive(cachedModuleCode));
+                                } else {
+                                    logger.warn("Using raw .dex files means that gestalt-di will not work." +
+                                                "Try combining them into a jar containing the META-INF directory.");
+                                }
                             }
                         }
                     } catch (Exception ignore) {
@@ -122,7 +122,7 @@ public class AndroidModulePathScanner extends ModulePathScanner {
 
                     registry.add(new Module(metadata,
                             new AndroidAssetsFileSource(assetManager, fullModulePath),
-                            classpaths, reflections, x -> true));
+                            classpaths, classIndex, x -> true));
                 }
             } catch (Exception ignore) {
             }

--- a/gestalt-android/src/main/java/org/terasology/gestalt/android/AndroidModulePathScanner.java
+++ b/gestalt-android/src/main/java/org/terasology/gestalt/android/AndroidModulePathScanner.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 The Terasology Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.gestalt.android;
+
+import android.content.res.AssetManager;
+import com.google.common.base.Charsets;
+import com.google.common.io.ByteStreams;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.gestalt.module.Module;
+import org.terasology.gestalt.module.ModuleMetadata;
+import org.terasology.gestalt.module.ModuleMetadataJsonAdapter;
+import org.terasology.gestalt.module.ModulePathScanner;
+import org.terasology.gestalt.module.ModuleRegistry;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link ModulePathScanner} derivative that scans the APK assets directory on Android for modules.
+ * It uses {@link AndroidAssetsFileSource} to create modules that directly use these files, removing the need to copy
+ * the modules into the app's data directory first.
+ */
+public class AndroidModulePathScanner extends ModulePathScanner {
+    private static final Logger logger = LoggerFactory.getLogger(AndroidModulePathScanner.class);
+    private final AssetManager assetManager;
+    private final File moduleDexesCache;
+
+    public AndroidModulePathScanner(AssetManager assetManager, File moduleDexesCache) {
+        super();
+        this.assetManager = assetManager;
+        this.moduleDexesCache = moduleDexesCache;
+    }
+
+    private void deleteModuleDexesCache(File file) {
+        if (file.isDirectory()) {
+            for (String subPath : file.list()) {
+                deleteModuleDexesCache(new File(file, subPath));
+            }
+        }
+        file.delete();
+    }
+
+    @Override
+    public void scan(ModuleRegistry registry, Collection<File> paths) {
+        if (moduleDexesCache.exists()) {
+            deleteModuleDexesCache(moduleDexesCache);
+        }
+
+        for (File path : paths) {
+            try {
+                for (String modulePath : assetManager.list(path.toString())) {
+                    String fullModulePath = path + "/" + modulePath;
+                    InputStream modInfoFile = tryOpenAsset(fullModulePath + "/module.json");
+                    if (modInfoFile == null) {
+                        logger.warn("Found a possible module without a module.json. Skipping...");
+                        continue;
+                    }
+
+                    ModuleMetadata metadata;
+                    try (Reader reader = new BufferedReader(new InputStreamReader(modInfoFile, Charsets.UTF_8))) {
+                        metadata = new ModuleMetadataJsonAdapter().read(reader);
+                    } catch (Exception e) {
+                        logger.error("Error reading module metadata", e);
+                        continue;
+                    }
+
+                    Reflections reflections = new Reflections();
+                    try {
+                        InputStream reflectionsFile = assetManager.open(fullModulePath + "/build/classes/reflections.cache");
+                        reflections.collect(reflectionsFile);
+                    } catch (FileNotFoundException ignore) {
+                        logger.warn("No reflections cache found for module. Is it an asset-only module?");
+                    } catch (Exception e) {
+                        logger.error("Error reading reflections", e);
+                    }
+
+                    List<File> classpaths = new ArrayList<>();
+                    try {
+                        for (String moduleDex : assetManager.list(fullModulePath + "/build/dexes")) {
+                            if (moduleDex.endsWith(".dex")) {
+                                new File(moduleDexesCache, modulePath).mkdirs();
+                                File cachedModuleDex = new File(moduleDexesCache, modulePath + "/" + moduleDex);
+                                try (InputStream inputStream = assetManager.open(fullModulePath + "/build/dexes/" + moduleDex)) {
+                                    try (FileOutputStream outputStream = new FileOutputStream(cachedModuleDex)) {
+                                        ByteStreams.copy(inputStream, outputStream);
+                                    } catch (Exception e) {
+                                        e.printStackTrace();
+                                    }
+                                } catch (IOException e) {
+                                    e.printStackTrace();
+                                }
+                                classpaths.add(cachedModuleDex);
+                            }
+                        }
+                    } catch (Exception ignore) {
+                    }
+
+                    registry.add(new Module(metadata,
+                            new AndroidAssetsFileSource(assetManager, fullModulePath),
+                            classpaths, reflections, x -> true));
+                }
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    private InputStream tryOpenAsset(String path) {
+        try {
+            return assetManager.open(path);
+        } catch (IOException ignore) {
+            return null;
+        }
+    }
+}

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleServiceRegistry.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/ModuleServiceRegistry.java
@@ -6,9 +6,7 @@ import org.terasology.gestalt.module.sandbox.PermissionProviderFactory;
 
 public class ModuleServiceRegistry extends ServiceRegistry {
     public ModuleServiceRegistry(PermissionProviderFactory permissionProviderFactory) {
-        with(ModulePathScanner.class);
         with(ModuleMetadataJsonAdapter.class);
-        with(ModulePathScanner.class);
         with(ModuleFactory.class);
         with(TableModuleRegistry.class);
         with(DependencyResolver.class);

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/SandboxTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/SandboxTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.module.Test1Scoped;
 import org.module.TestImplementation1;
+import org.terasology.context.Lifetime;
 import org.terasology.gestalt.di.BeanContext;
 import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.di.index.UrlClassIndex;
@@ -80,7 +81,9 @@ public class SandboxTest {
         Policy.setPolicy(new ModuleSecurityPolicy());
         System.setSecurityManager(new ModuleSecurityManager());
 
-        root = new DefaultBeanContext(new ModuleServiceRegistry(permissionProviderFactory));
+        ModuleServiceRegistry registry = new ModuleServiceRegistry(permissionProviderFactory);
+        registry.with(ModulePathScanner.class).lifetime(Lifetime.Singleton);
+        root = new DefaultBeanContext(registry);
         root.getBean(ModulePathScanner.class).scan(root.getBean(ModuleRegistry.class), Paths.get("test-modules").toFile());
         resolver = root.getBean(DependencyResolver.class);
     }

--- a/gestalt-module/src/test/java/org/terasology/gestalt/module/di/BeanContextInModuleTest.java
+++ b/gestalt-module/src/test/java/org/terasology/gestalt/module/di/BeanContextInModuleTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.module.TestImplementation1;
+import org.terasology.context.Lifetime;
 import org.terasology.gestalt.di.BeanContext;
 import org.terasology.gestalt.di.DefaultBeanContext;
 import org.terasology.gestalt.module.ModuleEnvironment;
@@ -24,7 +25,9 @@ public class BeanContextInModuleTest {
 
     @Before
     public void setup() {
-        BeanContext root = new DefaultBeanContext(new ModuleServiceRegistry(new PermitAllPermissionProviderFactory()));
+        ModuleServiceRegistry serviceRegistry = new ModuleServiceRegistry(new PermitAllPermissionProviderFactory());
+        serviceRegistry.with(ModulePathScanner.class).lifetime(Lifetime.Singleton);
+        BeanContext root = new DefaultBeanContext(serviceRegistry);
 
         ModulePathScanner scanner = root.getBean(ModulePathScanner.class);
         ModuleRegistry registry = root.getBean(ModuleRegistry.class);


### PR DESCRIPTION
This a variant of #124 adapated for the `develop` branch of gestalt. It addtionally adds the ability to load module dexes from `.jar` files, rather than just as a series of raw `.dex` files in a directory. This is needed because Android requires `jar` file sources for modules to access classpath resources, which `gestalt-di` uses.