### PR TITLE
build: upgrade dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,16 +27,16 @@ ext {
     android_annotation_version = "28.0.0"
 
     // Standard Utility
-    guava_version = "27.0.1-android"
-    slf4j_version = "1.7.25"
-    gson_version = "2.8.5"
+    guava_version = "31.1-android"
+    slf4j_version = "1.7.36"
+    gson_version = "2.9.0"
     jcip_annotation_version = "1.0"
 
     // Testing
     junit_version = "4.13.2"
-    jupiter_version = "5.7.1"
-    logback_version = "1.2.3"
-    mockito_version = "3.7.7"
+    jupiter_version = "5.8.2"
+    logback_version = "1.2.9"
+    mockito_version = "3.9.0"
 }
 
 allprojects {

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -5,6 +5,10 @@ apply from: "$rootDir/gradle/common.gradle"
 // Primary dependencies definition
 dependencies {
     api 'org.terasology:reflections:0.9.12-MB'
+    // Additional corrections for old reflections dependencies:
+    constraints {
+        implementation("org.javassist:javassist:3.29.0-GA")
+    }
 
     implementation project(":gestalt-util")
     implementation "com.google.guava:guava:$guava_version"


### PR DESCRIPTION
Checkmarx flagged the guava and logback versions.

Fixes #134.

I updated a few other things while I was there.

One exception is commons-vfs2: when I changed that to version 2.9.0, I was warned of transitive dependencies to a version of jackson-databind with vulnerabilities ([1][jdb1], [2][jdb2]). The current version doesn't seem to pull in jackson-databind at all. So I left well enough alone with that one.

[jdb1]: https://advisory.checkmarx.net/advisory/vulnerability/CVE-2020-36518/ "out-of-bounds write"
[jdb2]: https://advisory.checkmarx.net/advisory/vulnerability/Cxced0c06c-935c/ "uncontrolled resource consumption"