### PR TITLE
ci: adjust desired agent label light-java -> light

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label "light-java"
+        label "light"
     }
     stages {
         stage('Build') {


### PR DESCRIPTION
seems like the agent labels have changed over time. previously `light-java` is now called `light`

we might need java version specific label in addition. for instance, the current jenkins agent is jdk11. if we require jdk8 still, then we need to add a respective label. ideally jdk11 should be fine, potentially we need another build param for language level