### PR TITLE
refactor(version): adjust to new semver 0.10.2 release

### DIFF
--- a/gestalt-inject-java/build.gradle
+++ b/gestalt-inject-java/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.apache.commons:commons-vfs2:2.2'
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
-    implementation "com.github.zafarkhaja:java-semver:0.10.0"
+    implementation "com.github.zafarkhaja:java-semver:0.10.2"
 
     testImplementation project(":testpack:testpack-api")
     testImplementation "junit:junit:$junit_version"

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'org.apache.commons:commons-vfs2:2.2'
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
-    implementation "com.github.zafarkhaja:java-semver:0.10.2
+    implementation "com.github.zafarkhaja:java-semver:0.10.2"
 
     testImplementation project(":testpack:testpack-api")
     testAnnotationProcessor project(":gestalt-inject-java")

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'org.apache.commons:commons-vfs2:2.2'
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
-    implementation "com.github.zafarkhaja:java-semver:0.10.0"
+    implementation "com.github.zafarkhaja:java-semver:0.10.2
 
     testImplementation project(":testpack:testpack-api")
     testAnnotationProcessor project(":gestalt-inject-java")

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
@@ -61,7 +61,7 @@ public final class Version implements Comparable<Version> {
         }
 
 
-        final com.github.zafarkhaja.semver.Version baseVersion = com.github.zafarkhaja.semver.Version.forIntegers(major, minor, patch);
+        final com.github.zafarkhaja.semver.Version baseVersion = com.github.zafarkhaja.semver.Version.of(major, minor, patch);
         this.semver = snapshot ? baseVersion.setPreReleaseVersion(SNAPSHOT) : baseVersion;
     }
 
@@ -71,7 +71,7 @@ public final class Version implements Comparable<Version> {
      */
     public Version(String version) {
         try {
-            this.semver = com.github.zafarkhaja.semver.Version.valueOf(version);
+            this.semver = com.github.zafarkhaja.semver.Version.parse(version);
         } catch (ParseException e) {
             throw new VersionParseException("Invalid version '" + version + "' - must be of the form MAJOR.minor.patch");
         }
@@ -87,22 +87,22 @@ public final class Version implements Comparable<Version> {
     }
 
     public int getMajor() {
-        return semver.getMajorVersion();
+        return semver.majorVersion();
     }
 
     public int getMinor() {
-        return semver.getMinorVersion();
+        return semver.minorVersion();
     }
 
     public int getPatch() {
-        return semver.getPatchVersion();
+        return semver.patchVersion();
     }
 
     /**
      * @return Whether this version is a snapshot (work in progress)
      */
     public boolean isSnapshot() {
-        return !semver.getPreReleaseVersion().isEmpty();
+        return !semver.preReleaseVersion().isEmpty();
     }
 
     public Version getSnapshot() {
@@ -110,15 +110,15 @@ public final class Version implements Comparable<Version> {
     }
 
     public Version getNextMajorVersion() {
-        return new Version(semver.incrementMajorVersion());
+        return new Version(semver.nextMajorVersion());
     }
 
     public Version getNextMinorVersion() {
-        return new Version(semver.incrementMinorVersion());
+        return new Version(semver.nextMinorVersion());
     }
 
     public Version getNextPatchVersion() {
-        return new Version(semver.incrementPatchVersion());
+        return new Version(semver.nextPatchVersion());
     }
 
     @Override

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
@@ -87,15 +87,15 @@ public final class Version implements Comparable<Version> {
     }
 
     public int getMajor() {
-        return semver.majorVersion();
+        return (int) semver.majorVersion();
     }
 
     public int getMinor() {
-        return semver.minorVersion();
+        return (int) semver.minorVersion();
     }
 
     public int getPatch() {
-        return semver.patchVersion();
+        return (int) semver.patchVersion();
     }
 
     /**


### PR DESCRIPTION
- after zafarkhaja went MIA after 2015, AntiLaby took over and released 0.10.0 in 2019
- zafarkhaja came back now and published a conflicting 0.10.0 release with breaking changes
  - getMajorVersion, getMinorVersion, getPatchVersion methods were removed
- fixed by using new majorVersion, minorVersion, patchVersion methods
- also switched to suggested alternatives for methods deprecated with 0.10.0
  - forIntegers -> of
  - valueOf -> parse
  - getPreReleaseVersion -> preReleaseVersion
  - increment[Major|Minor|Patch]Version -> next[Major|Minor|Patch]Version

Update: there's a 0.10.2 patch release now, so we'll use that.

### References

- https://github.com/zafarkhaja/jsemver/releases/tag/v0.10.0
- https://github.com/zafarkhaja/jsemver/releases/tag/v0.10.2
- https://github.com/zafarkhaja/jsemver
- https://github.com/AntiLaby/jsemver
- https://github.com/MovingBlocks/jsemver