### PR TITLE
Gestalt 7 infrastructure updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label "java8"
+        label "light"
     }
     stages {
         stage('Build') {

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,7 @@ buildscript {
         }
         maven {
             name = "Terasology Artifactory"
-            url = "http://artifactory.terasology.org/artifactory/libs-release-local"
-            allowInsecureProtocol = true  // 😱
+            url = "https://artifactory.terasology.io/artifactory/libs-release-local"
         }
 
     }
@@ -57,8 +56,7 @@ allprojects {
             } else {
                 // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
                 name "Terasology Artifactory"
-                url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
-                allowInsecureProtocol true  // 😱
+                url "https://artifactory.terasology.io/artifactory/virtual-repo-live"
             }
         }
 

--- a/gestalt-android/build.gradle
+++ b/gestalt-android/build.gradle
@@ -72,11 +72,10 @@ project.afterEvaluate {
         repositories {
             maven {
                 name = 'TerasologyOrg'
-                allowInsecureProtocol true // 😱 - no https on our Artifactory yet
 
                 if (rootProject.hasProperty("publishRepo")) {
                     // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
-                    url = "http://artifactory.terasology.org/artifactory/$publishRepo"
+                    url = "https://artifactory.terasology.io/artifactory/$publishRepo"
 
                     logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
                 } else {
@@ -95,7 +94,7 @@ project.afterEvaluate {
                     }
 
                     logger.info("The final deduced publish repo is {}", deducedPublishRepo)
-                    url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
+                    url = "https://artifactory.terasology.io/artifactory/$deducedPublishRepo"
                 }
 
                 if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {

--- a/gestalt-module/build.gradle
+++ b/gestalt-module/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.apache.commons:commons-vfs2:2.2'
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "com.android.support:support-annotations:$android_annotation_version"
-    api "com.github.zafarkhaja:java-semver:0.10.0"
+    api "com.github.zafarkhaja:java-semver:0.10.2"
 
     testImplementation project(":testpack:testpack-api")
     testImplementation "ch.qos.logback:logback-classic:$logback_version"

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
@@ -48,7 +48,7 @@ public final class Version implements Comparable<Version> {
         }
 
 
-        final com.github.zafarkhaja.semver.Version baseVersion = com.github.zafarkhaja.semver.Version.forIntegers(major, minor, patch);
+        final com.github.zafarkhaja.semver.Version baseVersion = com.github.zafarkhaja.semver.Version.of(major, minor, patch);
         this.semver = snapshot ? baseVersion.setPreReleaseVersion(SNAPSHOT) : baseVersion;
     }
 
@@ -58,7 +58,7 @@ public final class Version implements Comparable<Version> {
      */
     public Version(String version) {
         try {
-            this.semver = com.github.zafarkhaja.semver.Version.valueOf(version);
+            this.semver = com.github.zafarkhaja.semver.Version.parse(version);
         } catch (ParseException e) {
             throw new VersionParseException("Invalid version '" + version + "' - must be of the form MAJOR.minor.patch");
         }
@@ -74,22 +74,22 @@ public final class Version implements Comparable<Version> {
     }
 
     public int getMajor() {
-        return semver.getMajorVersion();
+        return (int) semver.majorVersion();
     }
 
     public int getMinor() {
-        return semver.getMinorVersion();
+        return (int) semver.minorVersion();
     }
 
     public int getPatch() {
-        return semver.getPatchVersion();
+        return (int) semver.patchVersion();
     }
 
     /**
      * @return Whether this version is a snapshot (work in progress)
      */
     public boolean isSnapshot() {
-        return !semver.getPreReleaseVersion().isEmpty();
+        return !semver.preReleaseVersion().isEmpty();
     }
 
     public Version getSnapshot() {
@@ -97,15 +97,15 @@ public final class Version implements Comparable<Version> {
     }
 
     public Version getNextMajorVersion() {
-        return new Version(semver.incrementMajorVersion());
+        return new Version(semver.nextMajorVersion());
     }
 
     public Version getNextMinorVersion() {
-        return new Version(semver.incrementMinorVersion());
+        return new Version(semver.nextMinorVersion());
     }
 
     public Version getNextPatchVersion() {
-        return new Version(semver.incrementPatchVersion());
+        return new Version(semver.nextPatchVersion());
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=org.terasology.gestalt
 version=7.2.0-SNAPSHOT
 
 # Alternative resolution repo to use - this can be used to ignore "live" artifacts and only accept experimental ones.
-# alternativeResolutionRepo=http://artifactory.terasology.org/artifactory/virtual-nanoware-and-remote
+# alternativeResolutionRepo=https://artifactory.terasology.io/artifactory/virtual-nanoware-and-remote
 
 # Where to publish artifacts, if not to the default snapshot/release repos
 # Publishing a snapshot to a release-only repo will get an intended but quirky HTTP 409 Conflict error as of Nov 2014

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -46,11 +46,10 @@ publishing {
             repositories {
                 maven {
                     name = 'TerasologyOrg'
-                    allowInsecureProtocol true // 😱 - no https on our Artifactory yet
 
                     if (rootProject.hasProperty("publishRepo")) {
                         // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
-                        url = "http://artifactory.terasology.org/artifactory/$publishRepo"
+                        url = "https://artifactory.terasology.io/artifactory/$publishRepo"
 
                         logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
                     } else {
@@ -69,7 +68,7 @@ publishing {
                         }
 
                         logger.info("The final deduced publish repo is {}", deducedPublishRepo)
-                        url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
+                        url = "https://artifactory.terasology.io/artifactory/$deducedPublishRepo"
                     }
 
                     if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {


### PR DESCRIPTION
This pull request updates the `release/v7.x` branch to work with the current project infrastructure.

The branch now builds with the `light` agent, which may be using a version of Java newer than Java 8.

References to the older `artifactory.terasology.org` have been updated to use the newer `artifactory.terasology.io` instance instead.