### PR TITLE
Terasology Fixes

### DIFF
--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/event/Event.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/event/Event.java
@@ -16,11 +16,14 @@
 
 package org.terasology.gestalt.entitysystem.event;
 
+import org.terasology.context.annotation.IndexInherited;
+
 /**
  * Base interface for all events. An event is a notification that sent against an entity -
  * event handlers can then pick up and react to the event based on the components
  * the entity is composed of.
  */
+@IndexInherited
 public interface Event {
 
 }

--- a/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/event/package-info.java
+++ b/gestalt-entity-system/src/main/java/org/terasology/gestalt/entitysystem/event/package-info.java
@@ -2,4 +2,7 @@
  * Support for sending events against entities. Events are delivered to handling methods, filtered by
  * the type of event and the components that an entity is composed of.
  */
+@API
 package org.terasology.gestalt.entitysystem.event;
+
+import org.terasology.context.annotation.API;

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
@@ -107,7 +107,7 @@ public class ClassIndexProcessor extends AbstractProcessor {
     private void processAnnotationIndex(RoundEnvironment roundEnv, TypeElement annotation) {
         if (elementUtility.hasStereotype(annotation, Collections.singletonList(Index.class.getName()))) {
             for (Element type : roundEnv.getElementsAnnotatedWith(annotation)) {
-                if (type.getKind() == ElementKind.CLASS) {
+                if (type.getKind() == ElementKind.CLASS || type.getKind() == ElementKind.INTERFACE) {
                     annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), elementUtility.getTypes().erasure(type.asType()).toString());
                 } else if (type.getKind() == ElementKind.PACKAGE) {
                     PackageElement packageType = (PackageElement) type;


### PR DESCRIPTION
This pull request contains fixes needed for Terasology to work with Gestalt 8.

More specifically, it does the following:
- Include interfaces when creating annotation indexes (interfaces annotated with an indexed annotation should now be discoverable)
- Index event subclasses using the sub-types annotation processor
- Expose the `org.terasology.entitysystem.event` package to modules (so that they can use event handler types)