### PR TITLE
Revert "ci: add android builds to CI"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,10 @@
 pipeline {
     agent {
-        label "android"
+        label "light"
     }
     stages {
         stage('Build') {
             steps {
-                sh 'echo sdk.dir=/opt/android-sdk > local.properties'
                 sh './gradlew --info --console=plain jar'
             }
         }


### PR DESCRIPTION
This pull request reverts MovingBlocks/gestalt#128. The changes do not appear to work when publishing with the current version of Gradle.

Supported combinations can be found in the documentation for the [Android Gradle Plugin](https://developer.android.com/build/releases/gradle-plugin#updating-plugin).

The following error occurs:
```
FAILURE: Build failed with an exception.

* Where:
Build file '/home/jenkins/agent/workspace/Libraries_Gestalt_develop/gestalt-android/build.gradle' line: 150

* What went wrong:
Execution failed for task ':gestalt-android:generatePomFileForMavenPublication'.
> Could not apply withXml() to generated POM
   > Could not get unknown property 'compile' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.
```