### PR TITLE
build: Added configurations to apply constraints to dependencies `resolves` #134

### DIFF
--- a/gestalt-android-testbed/build.gradle
+++ b/gestalt-android-testbed/build.gradle
@@ -1,8 +1,8 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 plugins {
-    id("com.android.application")
-    id("project-report")
+    id 'com.android.application'
+    id 'project-report'
 }
 
 android {
@@ -16,8 +16,8 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     packagingOptions {
         merge "META-INF/annotations/*"
@@ -34,21 +34,36 @@ android {
 }
 
 dependencies {
-    implementation(fileTree(dir: "libs", include: ["*.jar"]))
-    implementation("com.android.support:appcompat-v7:28.0.0")
-    implementation("com.android.support.constraint:constraint-layout:1.1.3")
-    implementation(project(":gestalt-android"))
-    implementation(project(":gestalt-asset-core"))
-    implementation(project(":gestalt-entity-system"))
-    implementation(libs.guava)
-    implementation(libs.slf4j.api)
-    implementation("com.github.tony19:logback-android:1.3.0-3")
-    implementation(project(":testpack:testpack-api"))
-    testImplementation(libs.junit)
-    androidTestImplementation("com.android.support.test:runner:1.0.2")
-    androidTestImplementation("com.android.support.test.espresso:espresso-core:3.0.2")
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:28.0.0"
+    implementation "com.android.support.constraint:constraint-layout:1.1.3"
+    implementation project(":gestalt-android")
+    implementation project(":gestalt-asset-core")
+    implementation project(":gestalt-entity-system")
+    implementation libs.guava
+    implementation libs.slf4j.api
+    implementation "com.github.tony19:logback-android:1.3.0-3"
+    implementation project(":testpack:testpack-api")
+    testImplementation libs.junit
+    androidTestImplementation "com.android.support.test:runner:1.0.2"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.2"
 
-    annotationProcessor(project(":gestalt-inject-java"))
+    annotationProcessor project(":gestalt-inject-java")
+}
+
+configurations {
+    // Apply constraints to enforce specific versions
+    all {
+        resolutionStrategy {
+            force(
+                "com.android.support:appcompat-v7:28.0.0",
+                "com.android.support.constraint:constraint-layout:1.1.3",
+                "com.github.tony19:logback-android:1.3.0-3",
+                "com.android.support.test:runner:1.0.2",
+                "com.android.support.test.espresso:espresso-core:3.0.2"
+            )
+        }
+    }
 }
 
 // Android projects don't provide direct access to compileJava but this seems to work.
@@ -56,8 +71,8 @@ dependencies {
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
         // Adds Resources as parameter for AnnotationProcessor (gather ResourceIndex,
-        // also add resource as input for compilejava, for re-gathering ResourceIndex, when resource was changed.
+        // also add resource as input for compileJava, for re-gathering ResourceIndex, when resource was changed.
         inputs.files android.sourceSets.main.resources.srcDirs
-        options.compilerArgs = ["-Aresource=${android.sourceSets.main.resources.srcDirs.join(File.pathSeparator)}"]
+        options.compilerArgs.add("-Aresource=${android.sourceSets.main.resources.srcDirs.join(File.pathSeparator)}")
     }
 }

--- a/gestalt-android-testbed/build.gradle
+++ b/gestalt-android-testbed/build.gradle
@@ -1,8 +1,8 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 plugins {
-    id 'com.android.application'
-    id 'project-report'
+    id("com.android.application")
+    id("project-report")
 }
 
 android {
@@ -16,8 +16,8 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     packagingOptions {
         merge "META-INF/annotations/*"
@@ -34,36 +34,21 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "com.android.support:appcompat-v7:28.0.0"
-    implementation "com.android.support.constraint:constraint-layout:1.1.3"
-    implementation project(":gestalt-android")
-    implementation project(":gestalt-asset-core")
-    implementation project(":gestalt-entity-system")
-    implementation libs.guava
-    implementation libs.slf4j.api
-    implementation "com.github.tony19:logback-android:1.3.0-3"
-    implementation project(":testpack:testpack-api")
-    testImplementation libs.junit
-    androidTestImplementation "com.android.support.test:runner:1.0.2"
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.2"
+    implementation(fileTree(dir: "libs", include: ["*.jar"]))
+    implementation("com.android.support:appcompat-v7:28.0.0")
+    implementation("com.android.support.constraint:constraint-layout:1.1.3")
+    implementation(project(":gestalt-android"))
+    implementation(project(":gestalt-asset-core"))
+    implementation(project(":gestalt-entity-system"))
+    implementation(libs.guava)
+    implementation(libs.slf4j.api)
+    implementation("com.github.tony19:logback-android:1.3.0-3")
+    implementation(project(":testpack:testpack-api"))
+    testImplementation(libs.junit)
+    androidTestImplementation("com.android.support.test:runner:1.0.2")
+    androidTestImplementation("com.android.support.test.espresso:espresso-core:3.0.2")
 
-    annotationProcessor project(":gestalt-inject-java")
-}
-
-configurations {
-    // Apply constraints to enforce specific versions
-    all {
-        resolutionStrategy {
-            force(
-                "com.android.support:appcompat-v7:28.0.0",
-                "com.android.support.constraint:constraint-layout:1.1.3",
-                "com.github.tony19:logback-android:1.3.0-3",
-                "com.android.support.test:runner:1.0.2",
-                "com.android.support.test.espresso:espresso-core:3.0.2"
-            )
-        }
-    }
+    annotationProcessor(project(":gestalt-inject-java"))
 }
 
 // Android projects don't provide direct access to compileJava but this seems to work.
@@ -71,8 +56,8 @@ configurations {
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
         // Adds Resources as parameter for AnnotationProcessor (gather ResourceIndex,
-        // also add resource as input for compileJava, for re-gathering ResourceIndex, when resource was changed.
+        // also add resource as input for compilejava, for re-gathering ResourceIndex, when resource was changed.
         inputs.files android.sourceSets.main.resources.srcDirs
-        options.compilerArgs.add("-Aresource=${android.sourceSets.main.resources.srcDirs.join(File.pathSeparator)}")
+        options.compilerArgs = ["-Aresource=${android.sourceSets.main.resources.srcDirs.join(File.pathSeparator)}"]
     }
 }

--- a/gestalt-android-testbed/build.gradle
+++ b/gestalt-android-testbed/build.gradle
@@ -50,6 +50,20 @@ dependencies {
 
     annotationProcessor(project(":gestalt-inject-java"))
 }
+configurations {
+    // Apply constraints to enforce specific versions
+    all {
+        resolutionStrategy {
+            force(
+                "com.android.support:appcompat-v7:28.0.0",
+                "com.android.support.constraint:constraint-layout:1.1.3",
+                "com.github.tony19:logback-android:1.3.0-3",
+                "com.android.support.test:runner:1.0.2",
+                "com.android.support.test.espresso:espresso-core:3.0.2"
+            )
+        }
+    }
+}
 
 // Android projects don't provide direct access to compileJava but this seems to work.
 // https://stackoverflow.com/a/42297051

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AbstractFragmentDataProducer.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AbstractFragmentDataProducer.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 /**
  * An abstract implementation of AssetDataProducer aimed to ease the creation of producers that provide fragments from other assets.
  * <p>
@@ -71,7 +73,7 @@ public abstract class AbstractFragmentDataProducer<T extends AssetData, U extend
             return ImmutableSet.copyOf(Collections2.transform(assetManager.resolve(resourceName.toString(), rootAssetType), new Function<ResourceUrn, Name>() {
                 @Nullable
                 @Override
-                public Name apply(ResourceUrn input) {
+                public Name apply(@Nonnull ResourceUrn input) {
                     return input.getModuleName();
                 }
             }));

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AbstractFragmentDataProducer.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AbstractFragmentDataProducer.java
@@ -69,7 +69,6 @@ public abstract class AbstractFragmentDataProducer<T extends AssetData, U extend
     public Set<Name> getModulesProviding(Name resourceName) {
         if (resolveModuleFromRoot) {
             return ImmutableSet.copyOf(Collections2.transform(assetManager.resolve(resourceName.toString(), rootAssetType), new Function<ResourceUrn, Name>() {
-                @SuppressWarnings("null")
                 @Nullable
                 @Override
                 public Name apply(ResourceUrn input) {

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AbstractFragmentDataProducer.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AbstractFragmentDataProducer.java
@@ -69,6 +69,7 @@ public abstract class AbstractFragmentDataProducer<T extends AssetData, U extend
     public Set<Name> getModulesProviding(Name resourceName) {
         if (resolveModuleFromRoot) {
             return ImmutableSet.copyOf(Collections2.transform(assetManager.resolve(resourceName.toString(), rootAssetType), new Function<ResourceUrn, Name>() {
+                @SuppressWarnings("null")
                 @Nullable
                 @Override
                 public Name apply(ResourceUrn input) {

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -172,6 +172,7 @@ public abstract class Asset<T extends AssetData> {
             return true;
         }
         if (obj instanceof Asset) {
+            @SuppressWarnings("rawtypes")
             Asset other = (Asset) obj;
             return !urn.isInstance() && !other.urn.isInstance() && other.urn.equals(urn);
         }

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -172,7 +172,6 @@ public abstract class Asset<T extends AssetData> {
             return true;
         }
         if (obj instanceof Asset) {
-            @SuppressWarnings("rawtypes")
             Asset other = (Asset) obj;
             return !urn.isInstance() && !other.urn.isInstance() && other.urn.equals(urn);
         }

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/Asset.java
@@ -171,8 +171,8 @@ public abstract class Asset<T extends AssetData> {
         if (obj == this) {
             return true;
         }
-        if (obj instanceof Asset) {
-            Asset other = (Asset) obj;
+        if (obj instanceof Asset<?>) {
+            Asset<?> other = (Asset<?>) obj;
             return !urn.isInstance() && !other.urn.isInstance() && other.urn.equals(urn);
         }
         return false;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
@@ -45,7 +45,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
-import java.security.AccessController;
+import java.security.AccessController; // marked for removal(deprecated)
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
@@ -54,6 +54,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
+
+import javax.annotation.Nonnull;
 
 /**
  * AssetType manages all assets of a particular type/class.  It provides the ability to resolve and load assets by Urn, and caches assets so that there is only
@@ -67,6 +69,8 @@ import java.util.concurrent.Semaphore;
  */
 @API
 @ThreadSafe
+@SuppressWarnings({ "unchecked", "removal" })
+
 public final class AssetType<T extends Asset<U>, U extends AssetData> implements Closeable {
 
     private static final Logger logger = LoggerFactory.getLogger(AssetType.class);
@@ -101,7 +105,6 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param assetClass The class of asset this AssetType will manage.
      * @param factory    The factory used to convert AssetData to Assets for this type
      */
-    @SuppressWarnings("unchecked")
     public AssetType(Class<T> assetClass, AssetFactory<T, U> factory) {
         Preconditions.checkNotNull(assetClass);
         Preconditions.checkNotNull(factory);
@@ -131,7 +134,6 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     /**
      * Disposes any assets queued for disposal. This occurs if an asset is no longer referenced by anything.
      */
-    @SuppressWarnings("unchecked")
     public void processDisposal() {
         Reference<? extends Asset<U>> ref = disposalQueue.poll();
         while (ref != null) {
@@ -298,7 +300,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     }
 
     /**
-     * Creates and returns an instance of an asset, if possible. The following methods are used to create the copy, in order, with the first technique to succeeed used:
+     * Creates and returns an instance of an asset, if possible. The following methods are used to create the copy, in order, with the first technique to succeed used:
      * <ol>
      * <li>Delegate to the parent asset to create the copy</li>
      * <li>Loads the AssetData of the parent asset and create a new instance from that</li>
@@ -307,7 +309,6 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param urn The urn of the asset to create an instance of
      * @return An instance of the desired asset
      */
-    @SuppressWarnings("unchecked")
     public Optional<T> getInstanceAsset(ResourceUrn urn) {
         Optional<? extends T> parentAsset = getAsset(urn.getParentUrn());
         if (parentAsset.isPresent()) {
@@ -323,6 +324,8 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param asset The asset to create an instance of
      * @return The new instance, or {@link Optional#empty} if it could not be created
      */
+    
+    @SuppressWarnings({ "deprecation" })
     Optional<T> createInstance(Asset<U> asset) {
         Preconditions.checkArgument(assetClass.isAssignableFrom(asset.getClass()));
         Optional<? extends Asset<U>> result = asset.createCopy(asset.getUrn().getInstanceUrn());
@@ -351,6 +354,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param urn The urn of the resource to reload.
      * @return The asset if it exists (regardless of whether it was reloaded or not)
      */
+    @SuppressWarnings({ "deprecation" })
     public Optional<T> reload(ResourceUrn urn) {
         Preconditions.checkArgument(!urn.isInstance(), "Cannot reload an asset instance urn");
         ResourceUrn redirectUrn = followRedirects(urn);
@@ -484,7 +488,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
         return Sets.newLinkedHashSet(Collections2.transform(possibleModules, new Function<Name, ResourceUrn>() {
             @Nullable
             @Override
-            public ResourceUrn apply(Name input) {
+            public ResourceUrn apply(@Nonnull Name input) {
                 return new ResourceUrn(input, resourceName, fragmentName, instance);
             }
         }));
@@ -601,6 +605,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
             return true;
         }
         if (obj instanceof AssetType) {
+            @SuppressWarnings("rawtypes")
             AssetType other = (AssetType) obj;
             return assetClass.equals(other.assetClass);
         }

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
@@ -16,6 +16,7 @@
 
 package org.terasology.gestalt.assets;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.google.common.base.Function;
@@ -45,9 +46,9 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
+
+//import java.security.PrivilegedActionException;  //should i even remove these???(not sure)
+//import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +132,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     /**
      * Disposes any assets queued for disposal. This occurs if an asset is no longer referenced by anything.
      */
-    @SuppressWarnings("unchecked")
+    //@SuppressWarnings("unchecked")
     public void processDisposal() {
         Reference<? extends Asset<U>> ref = disposalQueue.poll();
         while (ref != null) {
@@ -298,7 +299,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     }
 
     /**
-     * Creates and returns an instance of an asset, if possible. The following methods are used to create the copy, in order, with the first technique to succeeed used:
+     * Creates and returns an instance of an asset, if possible. The following methods are used to create the copy, in order, with the first technique to succeed used:
      * <ol>
      * <li>Delegate to the parent asset to create the copy</li>
      * <li>Loads the AssetData of the parent asset and create a new instance from that</li>
@@ -307,7 +308,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param urn The urn of the asset to create an instance of
      * @return An instance of the desired asset
      */
-    @SuppressWarnings("unchecked")
+   // @SuppressWarnings("unchecked")
     public Optional<T> getInstanceAsset(ResourceUrn urn) {
         Optional<? extends T> parentAsset = getAsset(urn.getParentUrn());
         if (parentAsset.isPresent()) {
@@ -328,7 +329,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
         Optional<? extends Asset<U>> result = asset.createCopy(asset.getUrn().getInstanceUrn());
         if (!result.isPresent()) {
             try {
-                return AccessController.doPrivileged((PrivilegedExceptionAction<Optional<T>>) () -> {
+                
                     for (AssetDataProducer<U> producer : producers) {
                         Optional<U> data = producer.getAssetData(asset.getUrn());
                         if (data.isPresent()) {
@@ -336,8 +337,8 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
                         }
                     }
                     return Optional.ofNullable(assetClass.cast(result.get()));
-                });
-            } catch (PrivilegedActionException e) {
+                
+            } catch (Exception e) {
                 logger.error("Failed to load asset '" + asset.getUrn().getInstanceUrn() + "'", e.getCause());
             }
         }
@@ -355,7 +356,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
         Preconditions.checkArgument(!urn.isInstance(), "Cannot reload an asset instance urn");
         ResourceUrn redirectUrn = followRedirects(urn);
         try {
-            return AccessController.doPrivileged((PrivilegedExceptionAction<Optional<T>>) () -> {
+             
                 for (AssetDataProducer<U> producer : producers) {
                     Optional<U> data = producer.getAssetData(redirectUrn);
                     if (data.isPresent()) {
@@ -363,8 +364,8 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
                     }
                 }
                 return Optional.ofNullable(loadedAssets.get(redirectUrn));
-            });
-        } catch (PrivilegedActionException e) {
+            
+        } catch (Exception e) {
             if (redirectUrn.equals(urn)) {
                 logger.error("Failed to load asset '{}'", redirectUrn, e.getCause());
             } else {
@@ -484,7 +485,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
         return Sets.newLinkedHashSet(Collections2.transform(possibleModules, new Function<Name, ResourceUrn>() {
             @Nullable
             @Override
-            public ResourceUrn apply(Name input) {
+            public ResourceUrn apply(@NonNull Name input) {
                 return new ResourceUrn(input, resourceName, fragmentName, instance);
             }
         }));
@@ -601,7 +602,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
             return true;
         }
         if (obj instanceof AssetType) {
-            AssetType other = (AssetType) obj;
+            AssetType<?, ?> other = (AssetType<?, ?>) obj;
             return assetClass.equals(other.assetClass);
         }
         return false;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
@@ -47,8 +47,7 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
 
-//import java.security.PrivilegedActionException;  //should i even remove these???(not sure)
-//import java.security.PrivilegedExceptionAction;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
@@ -16,7 +16,7 @@
 
 package org.terasology.gestalt.assets;
 
-import android.support.annotation.NonNull;
+
 import android.support.annotation.Nullable;
 
 import com.google.common.base.Function;
@@ -55,6 +55,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
+
+import javax.annotation.Nonnull;
 
 /**
  * AssetType manages all assets of a particular type/class.  It provides the ability to resolve and load assets by Urn, and caches assets so that there is only
@@ -485,7 +487,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
         return Sets.newLinkedHashSet(Collections2.transform(possibleModules, new Function<Name, ResourceUrn>() {
             @Nullable
             @Override
-            public ResourceUrn apply(@NonNull Name input) {
+            public ResourceUrn apply(@Nonnull Name input) {
                 return new ResourceUrn(input, resourceName, fragmentName, instance);
             }
         }));

--- a/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
+++ b/gestalt-asset-core/src/main/java/org/terasology/gestalt/assets/AssetType.java
@@ -45,7 +45,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
-import java.security.AccessController; // marked for removal(deprecated)
+import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
@@ -54,8 +54,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
-
-import javax.annotation.Nonnull;
 
 /**
  * AssetType manages all assets of a particular type/class.  It provides the ability to resolve and load assets by Urn, and caches assets so that there is only
@@ -69,8 +67,6 @@ import javax.annotation.Nonnull;
  */
 @API
 @ThreadSafe
-@SuppressWarnings({ "unchecked", "removal" })
-
 public final class AssetType<T extends Asset<U>, U extends AssetData> implements Closeable {
 
     private static final Logger logger = LoggerFactory.getLogger(AssetType.class);
@@ -105,6 +101,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param assetClass The class of asset this AssetType will manage.
      * @param factory    The factory used to convert AssetData to Assets for this type
      */
+    @SuppressWarnings("unchecked")
     public AssetType(Class<T> assetClass, AssetFactory<T, U> factory) {
         Preconditions.checkNotNull(assetClass);
         Preconditions.checkNotNull(factory);
@@ -134,6 +131,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     /**
      * Disposes any assets queued for disposal. This occurs if an asset is no longer referenced by anything.
      */
+    @SuppressWarnings("unchecked")
     public void processDisposal() {
         Reference<? extends Asset<U>> ref = disposalQueue.poll();
         while (ref != null) {
@@ -300,7 +298,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
     }
 
     /**
-     * Creates and returns an instance of an asset, if possible. The following methods are used to create the copy, in order, with the first technique to succeed used:
+     * Creates and returns an instance of an asset, if possible. The following methods are used to create the copy, in order, with the first technique to succeeed used:
      * <ol>
      * <li>Delegate to the parent asset to create the copy</li>
      * <li>Loads the AssetData of the parent asset and create a new instance from that</li>
@@ -309,6 +307,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param urn The urn of the asset to create an instance of
      * @return An instance of the desired asset
      */
+    @SuppressWarnings("unchecked")
     public Optional<T> getInstanceAsset(ResourceUrn urn) {
         Optional<? extends T> parentAsset = getAsset(urn.getParentUrn());
         if (parentAsset.isPresent()) {
@@ -324,8 +323,6 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param asset The asset to create an instance of
      * @return The new instance, or {@link Optional#empty} if it could not be created
      */
-    
-    @SuppressWarnings({ "deprecation" })
     Optional<T> createInstance(Asset<U> asset) {
         Preconditions.checkArgument(assetClass.isAssignableFrom(asset.getClass()));
         Optional<? extends Asset<U>> result = asset.createCopy(asset.getUrn().getInstanceUrn());
@@ -354,7 +351,6 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
      * @param urn The urn of the resource to reload.
      * @return The asset if it exists (regardless of whether it was reloaded or not)
      */
-    @SuppressWarnings({ "deprecation" })
     public Optional<T> reload(ResourceUrn urn) {
         Preconditions.checkArgument(!urn.isInstance(), "Cannot reload an asset instance urn");
         ResourceUrn redirectUrn = followRedirects(urn);
@@ -488,7 +484,7 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
         return Sets.newLinkedHashSet(Collections2.transform(possibleModules, new Function<Name, ResourceUrn>() {
             @Nullable
             @Override
-            public ResourceUrn apply(@Nonnull Name input) {
+            public ResourceUrn apply(Name input) {
                 return new ResourceUrn(input, resourceName, fragmentName, instance);
             }
         }));
@@ -605,7 +601,6 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> implements
             return true;
         }
         if (obj instanceof AssetType) {
-            @SuppressWarnings("rawtypes")
             AssetType other = (AssetType) obj;
             return assetClass.equals(other.assetClass);
         }

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/AnnotationTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/AnnotationTypeWriter.java
@@ -6,7 +6,6 @@ import javax.annotation.processing.Filer;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,7 +16,7 @@ public class AnnotationTypeWriter {
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
-    private final Map<String, FileObject> files = new HashMap<>();
+    
 
     public AnnotationTypeWriter(Filer filer) {
         this.filer = filer;

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ServiceTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ServiceTypeWriter.java
@@ -6,7 +6,6 @@ import javax.annotation.processing.Filer;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,8 +16,7 @@ public class ServiceTypeWriter {
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
-    private final Map<String, FileObject> files = new HashMap<>();
-
+    
     public ServiceTypeWriter(Filer filer) {
         this.filer = filer;
     }

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/SubtypesTypeWriter.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/SubtypesTypeWriter.java
@@ -6,7 +6,6 @@ import javax.annotation.processing.Filer;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,7 +16,7 @@ public class SubtypesTypeWriter {
 
     private final Filer filer;
     private final Map<String, HashSet<String>> results = new HashMap<>();
-    private final Map<String, FileObject> files = new HashMap<>();
+    
 
     public SubtypesTypeWriter(Filer filer) {
         this.filer = filer;


### PR DESCRIPTION
Added configurations to apply constraints to the `build.gradle` dependencies to prevent  `gestalt` pulling in dependencies with known CVEs, directly or transitively through things like Reflections. Added some suppressions in various files and as well removed some unnecessary imports