### PR TITLE
feat: array/list parameter support for Gestalt-DI annotations

### DIFF
--- a/gestalt-di/src/main/java/org/terasology/gestalt/di/DefaultBeanContext.java
+++ b/gestalt-di/src/main/java/org/terasology/gestalt/di/DefaultBeanContext.java
@@ -358,7 +358,7 @@ public class DefaultBeanContext implements AutoCloseable, BeanContext {
     @Override
     public void close() throws Exception {
         for (Object o : this.boundObjects.values()) {
-            if (o instanceof AutoCloseable) {
+            if (o instanceof AutoCloseable && o != this) {
                 try {
                     ((AutoCloseable) o).close();
                 } catch (Exception e) {

--- a/gestalt-inject-java/build.gradle.kts
+++ b/gestalt-inject-java/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     testImplementation(libs.logback)
     testImplementation(libs.mockito)
 
-    implementation("com.squareup:javapoet:1.12.0")
+    implementation("com.squareup:javapoet:1.13.0")
     implementation("javax.inject:javax.inject:1")
     implementation(project(":gestalt-inject"))
 }

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/BeanDefinitionProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/BeanDefinitionProcessor.java
@@ -205,15 +205,22 @@ public class BeanDefinitionProcessor extends AbstractProcessor {
             return super.visitType(e, className);
         }
 
-        private Object getValue(Object target) {
+        private Object getValue(TypeMirror type, Object target) {
             Object result;
             if (target instanceof String) {
                 result = String.format("\"%s\"", target);
+            } else if (target instanceof List) {
+                if (((List<?>) target).isEmpty()) {
+                    result = "new " + type + "{}";
+                } else {
+                    result = target;
+                }
+            } else if (type.getKind() == TypeKind.DECLARED && ((DeclaredType) type).asElement().getKind() == ElementKind.ENUM) {
+                result = type + "." + target;
             } else {
                 result = target;
             }
             return result;
-
         }
 
         private List<CodeBlock> buildAnnotationValues(List<? extends AnnotationMirror> mirrors) {
@@ -228,7 +235,7 @@ public class BeanDefinitionProcessor extends AbstractProcessor {
                         ExecutableElement executableElement = (ExecutableElement) element;
                         AnnotationValue value = executableElement.getDefaultValue();
                         if (value != null) {
-                            defaults.add(CodeBlock.of("$S,$L", executableElement.getSimpleName(), getValue(value.getValue())));
+                            defaults.add(CodeBlock.of("$S,$L", executableElement.getSimpleName(), getValue(executableElement.getReturnType(), value.getValue())));
                         }
                     }
                 }
@@ -237,7 +244,7 @@ public class BeanDefinitionProcessor extends AbstractProcessor {
                     ExecutableElement executableElement = entry.getKey();
                     AnnotationValue value = entry.getValue();
                     if (value != null) {
-                        values.add(CodeBlock.of("$S,$L", executableElement.getSimpleName(), getValue(value.getValue())));
+                        values.add(CodeBlock.of("$S,$L", executableElement.getSimpleName(), getValue(executableElement.asType(), value.getValue())));
                     }
                 }
 

--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/BeanDefinitionProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/BeanDefinitionProcessor.java
@@ -244,7 +244,7 @@ public class BeanDefinitionProcessor extends AbstractProcessor {
                     ExecutableElement executableElement = entry.getKey();
                     AnnotationValue value = entry.getValue();
                     if (value != null) {
-                        values.add(CodeBlock.of("$S,$L", executableElement.getSimpleName(), getValue(executableElement.asType(), value.getValue())));
+                        values.add(CodeBlock.of("$S,$L", executableElement.getSimpleName(), getValue(executableElement.getReturnType(), value.getValue())));
                     }
                 }
 

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
@@ -110,7 +110,7 @@ public class ClasspathFileSource implements ModuleFileSource {
         if (filepath.stream().anyMatch(s -> s.equals(".."))) {
             return Optional.empty();
         }
-        String fullpath = buildPathString(filepath);
+        String fullpath = buildPathString(filepath, false);
         if (classLoader.getResource(fullpath) != null) {
             return Optional.of(new ClasspathSourceFileReference(fullpath, extractSubpath(basePath, fullpath), classLoader));
         } else {
@@ -120,7 +120,7 @@ public class ClasspathFileSource implements ModuleFileSource {
 
     @Override
     public Collection<FileReference> getFilesInPath(boolean recursive, List<String> path) {
-        String fullPath = buildPathString(path);
+        String fullPath = buildPathString(path, true);
         Stream<String> candidates = files
                 .stream()
                 .filter(file -> file.startsWith(fullPath))
@@ -137,7 +137,7 @@ public class ClasspathFileSource implements ModuleFileSource {
 
     @Override
     public Set<String> getSubpaths(List<String> path) {
-        String fullPath = buildPathString(path);
+        String fullPath = buildPathString(path, true);
         return files
                 .stream()
                 .filter(file -> file.startsWith(fullPath))
@@ -149,12 +149,15 @@ public class ClasspathFileSource implements ModuleFileSource {
                 .collect(Collectors.toSet());
     }
 
-    private String buildPathString(List<String> path) {
+    private String buildPathString(List<String> path, boolean isDirectory) {
         String fullPath;
         if (path.isEmpty() || (path.size() == 1 && path.get(0).isEmpty())) {
             fullPath = basePath;
         } else {
-            fullPath = basePath + CLASS_PATH_JOINER.join(path) + CLASS_PATH_SEPARATOR;
+            fullPath = basePath + CLASS_PATH_JOINER.join(path);
+            if (isDirectory) {
+                fullPath += CLASS_PATH_SEPARATOR;
+            }
         }
         return fullPath;
     }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/naming/Version.java
@@ -116,7 +116,7 @@ public final class Version implements Comparable<Version> {
      * @return true if this version is a snapshot
      */
     public boolean isSnapshot() {
-        return !semver.preReleaseVersion().isEmpty();
+        return semver.preReleaseVersion().isPresent();
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1536m
 group=org.terasology.gestalt
-version=8.0.0-SNAPSHOT
+version=8.0.2-SNAPSHOT
 
 # Alternative resolution repo to use - this can be used to ignore "live" artifacts and only accept experimental ones.
 # alternativeResolutionRepo=https://artifactory.terasology.io/artifactory/virtual-nanoware-and-remote


### PR DESCRIPTION
These changes are needed for Terasology to work with Gestalt DI. This is to go along with the main Terasology pull request.

It appears to do the following (although I am no longer certain of this):
 - Add additional input validation to catch null beans when closing the context
 - Upgrade the JavaPoet library (although I am unable to recall why by this point)
 - Fixes for using array/list values as annotation parameters when inspected by Gestalt DI's annotation processor
 - Change `!semver.preReleaseVersion().isEmpty()` to `semver.preReleaseVersion().isPresent()` (this may have been due to a breaking ABI change in the JSemver library)