### PR TITLE
Potentially address subtle bug with file paths getting a trailing slash

### DIFF
--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
@@ -104,8 +104,7 @@ public class ClasspathFileSource implements ModuleFileSource {
         }
         String fullpath = buildPathString(filepath, false);
         if (classLoader.getResource(fullpath) != null) {
-            return Optional
-                    .of(new ClasspathSourceFileReference(fullpath, extractSubpath(basePath, fullpath), classLoader));
+            return Optional.of(new ClasspathSourceFileReference(fullpath, extractSubpath(basePath, fullpath), classLoader));
         } else {
             return Optional.empty();
         }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/resources/ClasspathFileSource.java
@@ -102,9 +102,10 @@ public class ClasspathFileSource implements ModuleFileSource {
         if (filepath.stream().anyMatch(s -> s.equals(".."))) {
             return Optional.empty();
         }
-        String fullpath = buildPathString(filepath);
+        String fullpath = buildPathString(filepath, false);
         if (classLoader.getResource(fullpath) != null) {
-            return Optional.of(new ClasspathSourceFileReference(fullpath, extractSubpath(basePath, fullpath), classLoader));
+            return Optional
+                    .of(new ClasspathSourceFileReference(fullpath, extractSubpath(basePath, fullpath), classLoader));
         } else {
             return Optional.empty();
         }
@@ -112,7 +113,7 @@ public class ClasspathFileSource implements ModuleFileSource {
 
     @Override
     public Collection<FileReference> getFilesInPath(boolean recursive, List<String> path) {
-        String fullPath = buildPathString(path);
+        String fullPath = buildPathString(path, true);
         Stream<String> candidates = files
                 .stream()
                 .filter(file -> file.startsWith(fullPath))
@@ -129,7 +130,7 @@ public class ClasspathFileSource implements ModuleFileSource {
 
     @Override
     public Set<String> getSubpaths(List<String> path) {
-        String fullPath = buildPathString(path);
+        String fullPath = buildPathString(path, true);
         return files
                 .stream()
                 .filter(file -> file.startsWith(fullPath))
@@ -141,12 +142,15 @@ public class ClasspathFileSource implements ModuleFileSource {
                 .collect(Collectors.toSet());
     }
 
-    private String buildPathString(List<String> path) {
+    private String buildPathString(List<String> path, boolean isDirectory) {
         String fullPath;
         if (path.isEmpty() || (path.size() == 1 && path.get(0).isEmpty())) {
             fullPath = basePath;
         } else {
-            fullPath = basePath + CLASS_PATH_JOINER.join(path) + CLASS_PATH_SEPARATOR;
+            fullPath = basePath + CLASS_PATH_JOINER.join(path);
+            if (isDirectory) {
+                fullPath += CLASS_PATH_SEPARATOR;
+            }
         }
         return fullPath;
     }


### PR DESCRIPTION
The new Antigravity IDE by Google and Gemini 3 Pro found this one while I was trying to write Terasology tests validating various ways to get resources. It sounded reasonable and tested out - will let the AI explain further! Leaving this in a PR just so I don't forget the what and why, it doesn't need to merge any time soon.

Explanation of the Gestalt Fix

The issue was in ClasspathFileSource.buildPathString(), which was unconditionally appending a slash (/) to the path.

* The Mechanism: getFile(path) calls buildPathString(path) and then classLoader.getResource(fullPath).
* The Problem:
  * For Directories: A trailing slash is fine (and often correct).
  * For Files on Disk: Most OS filesystems are lenient and ignore the trailing slash.
  * For Files in JARs: The JarURLConnection / ClassLoader is strict. path/to/file.txt exists, but path/to/file.txt/ implies a directory named file.txt, which does not exist.
* Why it failed: When running from source (loose files), the OS likely handled the trailing slash gracefully. When running with the engine as a JAR (which ModuleLoadingTest seems to be doing for the engine module), the strict JAR lookup failed.

Is it safe? Yes. getFile() returns a FileReference, which is intended for reading files (it has an open() method for streams). It is not typically used for directories. Even if it were, ClassLoader.getResource generally handles directory paths without trailing slashes correctly anyway. The fix simply constructs the path exactly as requested for getFile, bypassing the directory-oriented helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `ClasspathFileSource` to only append a trailing slash for directories, not files.
> 
> - **gestalt-module**:
>   - `ClasspathFileSource`:
>     - Change `buildPathString(List<String> path)` to `buildPathString(List<String> path, boolean isDirectory)`.
>     - `getFile(...)` now calls `buildPathString(..., false)` (no trailing slash for files).
>     - `getFilesInPath(...)` and `getSubpaths(...)` now call `buildPathString(..., true)` (trailing slash for directories).
>     - Path construction now appends `"/"` only when `isDirectory` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e309888a04474775b5cd667b7196dc9eef3c7c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->