### PR TITLE
fix(gestalt-inject-java): use binary name for nested classes in class index

### DIFF
--- a/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
+++ b/gestalt-inject-java/src/main/java/org/terasology/gestalt/annotation/processing/ClassIndexProcessor.java
@@ -97,8 +97,12 @@ public class ClassIndexProcessor extends AbstractProcessor {
                         TypeMirror candidate = supers.poll();
                         if (candidate.getKind() != TypeKind.NONE) {
                             if (elementUtility.hasStereotype(elementUtility.getTypes().asElement(candidate),
-                                    Collections.singletonList(IndexInherited.class.getName())))
-                                subtypesTypeWriter.writeSubType(elementUtility.getTypes().erasure(candidate).toString(), elementUtility.getTypes().erasure(type.asType()).toString());
+                                    Collections.singletonList(IndexInherited.class.getName()))) {
+                                TypeElement candidateElement = (TypeElement) elementUtility.getTypes().asElement(elementUtility.getTypes().erasure(candidate));
+                                TypeElement erasedType = (TypeElement) elementUtility.getTypes().asElement(elementUtility.getTypes().erasure(type.asType()));
+                                subtypesTypeWriter.writeSubType(elementUtility.getElements().getBinaryName(candidateElement).toString(),
+                                        elementUtility.getElements().getBinaryName(erasedType).toString());
+                            }
                             supers.addAll(elementUtility.getTypes().directSupertypes(candidate));
                         }
                     }
@@ -111,7 +115,8 @@ public class ClassIndexProcessor extends AbstractProcessor {
         if (elementUtility.hasStereotype(annotation, Collections.singletonList(Index.class.getName()))) {
             for (Element type : roundEnv.getElementsAnnotatedWith(annotation)) {
                 if (type.getKind() == ElementKind.CLASS || type.getKind() == ElementKind.INTERFACE) {
-                    annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), elementUtility.getTypes().erasure(type.asType()).toString());
+                    TypeElement erasedType = (TypeElement) elementUtility.getTypes().asElement(elementUtility.getTypes().erasure(type.asType()));
+                    annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), elementUtility.getElements().getBinaryName(erasedType).toString());
                 } else if (type.getKind() == ElementKind.PACKAGE) {
                     PackageElement packageType = (PackageElement) type;
                     annotationTypeWriter.writeAnnotation(annotation.getQualifiedName().toString(), packageType.getQualifiedName().toString() + ".package-info");


### PR DESCRIPTION
## Summary
- `ClassIndexProcessor` wrote nested types (e.g. `Outer.Inner`) using `TypeMirror#toString()`, which renders the dotted/canonical form instead of the `Outer$Inner` binary name `ClassLoader.loadClass()` requires. This made `APIScanner.scan()` throw `ClassNotFoundException` for any `@API`-annotated nested class or interface (surfaced via Terasology's `MeshBuilder.TextureMapper`). Fixed both `processAnnotationIndex` and `processSubtypeIndexByDirectMarked` to use `Elements#getBinaryName()`, matching the pattern already used by `processSubtypeIndexInReverseWay`.
- Bumped the Gradle wrapper from 8.10.2 to 9.6.1 since 8.10.2 doesn't run on newer JDKs (e.g. 26).

## Test plan
- [x] `gradle :gestalt-inject-java:compileJava` succeeds
- [ ] Downstream Terasology `Missing facet provider` / `ClassNotFoundException` symptoms resolved once this is republished

🤖 Generated with [Claude Code](https://claude.com/claude-code)