### PR TITLE
ci: add Android Java API compatibility checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ hs_err_pid*
 
 # Ignore Gradle
 /.gradle/
+/build-logic/.gradle
 build/
 local.properties
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,13 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+}
+
+dependencies {
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -10,4 +10,5 @@ repositories {
 }
 
 dependencies {
+    implementation("ru.vyarus:gradle-animalsniffer-plugin:2.0.1")
 }

--- a/build-logic/src/main/kotlin/gestalt-library-common.gradle.kts
+++ b/build-logic/src/main/kotlin/gestalt-library-common.gradle.kts
@@ -1,9 +1,11 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2026 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // Most typical common config, but not quite global
-apply(plugin = "java-library")
-apply(plugin = "maven-publish")
+plugins {
+    `java-library`
+    `maven-publish`
+}
 
 extensions.configure<JavaPluginExtension> {
     withSourcesJar()

--- a/build-logic/src/main/kotlin/gestalt-library-common.gradle.kts
+++ b/build-logic/src/main/kotlin/gestalt-library-common.gradle.kts
@@ -5,6 +5,11 @@
 plugins {
     `java-library`
     `maven-publish`
+    id("ru.vyarus.animalsniffer")
+}
+
+dependencies {
+    add("signature", "com.toasttab.android:gummy-bears-api-24:0.15.0:coreLib2@signature")
 }
 
 extensions.configure<JavaPluginExtension> {
@@ -13,6 +18,11 @@ extensions.configure<JavaPluginExtension> {
 
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+}
+
+extensions.configure<ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension> {
+    // java.nio.* APIs can be desugared by D8. java.io.File.toPath() also needs to be excluded.
+    ignore = listOf("java.nio.file.*", "java.io.File")
 }
 
 // Extra details provided for unit tests

--- a/gestalt-android/build.gradle
+++ b/gestalt-android/build.gradle
@@ -3,6 +3,7 @@
 plugins {
     id("com.android.library")
     id("maven-publish")
+    id("ru.vyarus.animalsniffer") version "2.0.1"
 }
 
 android {
@@ -30,7 +31,14 @@ android {
     lintOptions {
         lintConfig file("lintconfig.xml")
     }
+    lint {
+        // Somehow, AndroidAssetsFileSource.java breaks this lint.
+        disable "BidiSpoofing"
+    }
+}
 
+tasks.withType(AnimalSniffer) {
+    ignoreFailures = false
 }
 
 dependencies {
@@ -46,6 +54,8 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+
+    signature("com.toasttab.android:gummy-bears-api-24:0.15.0:coreLib2@signature")
 }
 
 task androidJavadocs(type: Javadoc) {

--- a/gestalt-asset-core/build.gradle.kts
+++ b/gestalt-asset-core/build.gradle.kts
@@ -1,9 +1,7 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-apply(from = "$rootDir/gradle/common.gradle.kts")
-
 plugins {
-    `java-library`
+    id ("gestalt-library-common")
 }
 
 // Primary dependencies definition

--- a/gestalt-di/build.gradle.kts
+++ b/gestalt-di/build.gradle.kts
@@ -1,9 +1,7 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-apply(from = "$rootDir/gradle/common.gradle.kts")
-
 plugins {
-    `java-library`
+    id("gestalt-library-common")
 }
 
 tasks.register<Copy>("gatherJarModules") {

--- a/gestalt-entity-system/build.gradle.kts
+++ b/gestalt-entity-system/build.gradle.kts
@@ -1,9 +1,7 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-apply(from = "$rootDir/gradle/common.gradle.kts")
-
 plugins {
-    `java-library`
+    id("gestalt-library-common")
 }
 
 dependencies {

--- a/gestalt-es-perf/build.gradle.kts
+++ b/gestalt-es-perf/build.gradle.kts
@@ -1,9 +1,7 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-apply(from = "$rootDir/gradle/common.gradle.kts")
-
 plugins {
-    `java-library`
+    id("gestalt-library-common")
 }
 
 dependencies {
@@ -29,7 +27,7 @@ description = "High performance access methods to replace the use of reflections
  */
 
 // Register the gatherJarModules task
-val gatherJarModules by tasks.registering(Copy::class) {
+val gatherJarModules = tasks.register<Copy>("gatherJarModules") {
     dependsOn(":testpack:moduleF:jar")
     from("../testpack/moduleF/build/libs/")
     into("test-modules")
@@ -37,7 +35,7 @@ val gatherJarModules by tasks.registering(Copy::class) {
 }
 
 // Register the gatherModules task
-val gatherModules by tasks.registering {
+val gatherModules = tasks.register("gatherModules") {
     dependsOn(":gestalt-es-perf:gatherJarModules")
 }
 

--- a/gestalt-es-perf/build.gradle.kts
+++ b/gestalt-es-perf/build.gradle.kts
@@ -43,3 +43,8 @@ val gatherModules = tasks.register("gatherModules") {
 tasks.named("test") {
     dependsOn(gatherModules)
 }
+
+tasks.withType<ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer> {
+    // The gestalt-es-perf library is not intended for use on Android.
+    exclude("**/*")
+}

--- a/gestalt-inject-java/build.gradle.kts
+++ b/gestalt-inject-java/build.gradle.kts
@@ -1,9 +1,7 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-apply(from = "$rootDir/gradle/common.gradle.kts")
-
 plugins {
-    `java-library`
+    id("gestalt-library-common")
 }
 
 dependencies {

--- a/gestalt-inject-java/build.gradle.kts
+++ b/gestalt-inject-java/build.gradle.kts
@@ -27,3 +27,8 @@ dependencies {
 tasks.withType<AbstractTestTask>().configureEach {
     failOnNoDiscoveredTests = false
 }
+
+tasks.withType<ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer> {
+    // The gestalt-inject-java annotation processor is only used at compile-time and not intended for use on Android.
+    exclude("**/*")
+}

--- a/gestalt-inject/build.gradle.kts
+++ b/gestalt-inject/build.gradle.kts
@@ -1,9 +1,7 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-apply(from = "$rootDir/gradle/common.gradle.kts")
-
 plugins {
-    `java-library`
+    id("gestalt-library-common")
 }
 
 dependencies {

--- a/gestalt-module/build.gradle.kts
+++ b/gestalt-module/build.gradle.kts
@@ -1,9 +1,8 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-apply(from = "$rootDir/gradle/common.gradle.kts")
 
 plugins {
-    `java-library`
+    id ("gestalt-library-common")
 }
 
 dependencies {

--- a/gestalt-util/build.gradle.kts
+++ b/gestalt-util/build.gradle.kts
@@ -1,9 +1,8 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
-apply(from = "$rootDir/gradle/common.gradle.kts")
 
 plugins {
-    `java-library`
+    id("gestalt-library-common")
 }
 
 // Primary dependencies definition

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,10 @@ dependencyResolutionManagement {
     }
 }
 
+pluginManagement {
+    includeBuild("build-logic")
+}
+
 include(
     "gestalt-util",
     "gestalt-di",


### PR DESCRIPTION
This pull request introduces the [`gradle-animalsniffer-plugin`](https://github.com/xvik/gradle-animalsniffer-plugin) into the testing process to verify that Gestalt libraries do not call APIs which would be unavailable at runtime on Android. The API signatures are provided by the [`gummy-bears`](https://github.com/open-toast/gummy-bears) project.

The legacy `common.gradle.kts` shared logic is also moved into a more modern Gradle convention plugin, which should be easier to work with.

### Further Rationale
Android is an unusual platform from a build perspective due to it having lacking support for many Java APIs. For a long time, approximately Java 8 was the only supported baseline. Java 11 support was introduced in Android 12 (2021) and Java 17 support in Android 14 (2023). We still support all the way back to Android 7 currently (my preference).

Typically, if you wanted to ensure that code still ran under an older JVM runtime, you would compile the code using `-source <java_version>` and `-target <java_version>`, with `-release <java_version>` replacing these two from Java 9. This ensures that the code is compatible by limiting the available classes but also has the consequence of limiting you to using solely the language features supported by that old version.

The Android build tools offers [the `D8` dexer](https://developer.android.com/studio/write/java8-support) as an alternative. Strictly speaking, D8 is a tool used to translate JVM bytecode into a format compatible with Android's runtime. As part of this process, it also performs a "desugaring" step, allowing features from newer Java runtimes to be backported at build time in a few cases. This breaks the assumptions of the Java compiler that language features are tied to specific runtimes and allows us to use newer language features without any of the corresponding newer APIs being available. If any of those unavailable APIs happen to be in-use, then it will likely result in an unexpected runtime failure when the class cannot be found. The plugin introduced here performs more strict checks on the classes used by our libraries in an attempt to prevent such scenarios.