### PR TITLE
fix(module): log APIScanner class-not-found at info, not warn+stacktrace

### DIFF
--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/APIScanner.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/APIScanner.java
@@ -78,7 +78,7 @@ public class APIScanner {
                     }
                 }
             } catch (ClassNotFoundException e) {
-                logger.info("Class {} not found on classloader {} - expected if it belongs to a module's own classloader instead", apiClass, forClassLoader);
+                logger.info("Class {} not found on classloader {}", apiClass, forClassLoader);
             }
         }
     }

--- a/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/APIScanner.java
+++ b/gestalt-module/src/main/java/org/terasology/gestalt/module/sandbox/APIScanner.java
@@ -78,7 +78,7 @@ public class APIScanner {
                     }
                 }
             } catch (ClassNotFoundException e) {
-                logger.warn("Class not found", e);
+                logger.info("Class {} not found on classloader {} - expected if it belongs to a module's own classloader instead", apiClass, forClassLoader);
             }
         }
     }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `APIScanner.scan()` logged a full stack trace at WARN for every module class
  it couldn't resolve on the given classloader. This fires routinely — the
  engine's `setupSandbox()` scans every registered module's class index
  before that module's classes are loaded onto the classloader, so most
  non-engine modules trip it on every startup. Downgraded to a one-line INFO
  naming the class and the classloader checked.

## Test plan

- [ ] Run `Terasology Latest.app` and confirm startup no longer logs
      `ClassNotFoundException` stack traces from `APIScanner`, just INFO lines

## Related

- See jenkins.terasology.io Omega build console output that surfaced this
