### PR TITLE
build: clear Gradle 10 deprecations, bump wrapper to 9.7.0

### DIFF
--- a/gestalt-module/build.gradle.kts
+++ b/gestalt-module/build.gradle.kts
@@ -42,7 +42,7 @@ tasks.named<JavaCompile>("compileTestJava") {
 description = "Provides support for modules - java libraries that can be activated at runtime and run in a sandboxed environment"
 
 // Task registrations
-val gatherJarModules by tasks.registering(Copy::class) {
+val gatherJarModules = tasks.register<Copy>("gatherJarModules") {
     dependsOn(":testpack:moduleA:jar", ":testpack:moduleB:jar", ":testpack:moduleC:jar", ":testpack:moduleD:jar")
     from("../testpack/moduleA/build/libs/")
     from("../testpack/moduleB/build/libs/")
@@ -52,7 +52,7 @@ val gatherJarModules by tasks.registering(Copy::class) {
     include("*.jar")
 }
 
-val copyModuleELibs by tasks.registering(Copy::class) {
+val copyModuleELibs = tasks.register<Copy>("copyModuleELibs") {
     dependsOn(":testpack:moduleA:jar", ":testpack:moduleD:jar")
     from("../testpack/moduleA/build/libs")
     from("../testpack/moduleD/build/libs")
@@ -60,17 +60,17 @@ val copyModuleELibs by tasks.registering(Copy::class) {
     include("*.jar")
 }
 
-val copyModuleEInfo by tasks.registering(Copy::class) {
+val copyModuleEInfo = tasks.register<Copy>("copyModuleEInfo") {
     from("../testpack/moduleE")
     into("test-modules/moduleE")
     include("*.json")
 }
 
-val createModuleE by tasks.registering {
+val createModuleE = tasks.register("createModuleE") {
     dependsOn(":gestalt-module:copyModuleEInfo", ":gestalt-module:copyModuleELibs")
 }
 
-val gatherModules by tasks.registering {
+val gatherModules = tasks.register("gatherModules") {
     dependsOn(":gestalt-module:gatherJarModules", ":gestalt-module:createModuleE")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/testpack/testpack-api/build.gradle
+++ b/testpack/testpack-api/build.gradle
@@ -8,6 +8,6 @@ dependencies {
 }
 
 tasks.compileJava {
-    java.sourceCompatibility JavaVersion.VERSION_17
-    java.targetCompatibility JavaVersion.VERSION_17
+    java.sourceCompatibility = JavaVersion.VERSION_17
+    java.targetCompatibility = JavaVersion.VERSION_17
 }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Clears the two Gradle-10-scheduled-for-removal deprecations that are ours (Kotlin DSL `by registering` delegate, Groovy space-assignment), found while building against Gradle 9.7.0.
- Bumps the wrapper from 9.6.1 to 9.7.0 so the warnings are visible at all.
- One remaining warning traces into `gradle-animalsniffer-plugin` 2.0.1's own `ReportingExtension.file()` call — already the latest release, needs an upstream plugin fix, not addressed here.

## Test plan

- [x] `./gradlew build -x test --warning-mode=all` — clean of our own Gradle-10 warnings, BUILD SUCCESSFUL.

## Related

- Companion to MovingBlocks/Terasology#5362 which did the same for the engine repo and flagged gestalt/TeraNUI as needing their own PRs.
